### PR TITLE
docs: add SSO and Angular auth questions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   build:
-    name: Prettier and build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on:
+"on":
   pull_request:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,6 @@ name: Build
 
 "on":
   pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Prettier and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npx prettier "!package-lock.json" . --ignore-path .gitignore --check
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 name: Build
 
-"on":
+on:
   pull_request:
-  push:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,39 +1,39 @@
 name: Build
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    pull_request:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
 
 permissions:
-  contents: read
+    contents: read
 
 concurrency:
-  group: build-${{ github.ref }}
-  cancel-in-progress: true
+    group: build-${{ github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  build:
-    name: Prettier and build
-    runs-on: ubuntu-latest
+    build:
+        name: Prettier and build
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Check formatting
-        run: npx prettier "!package-lock.json" . --ignore-path .gitignore --check
+            - name: Check formatting
+              run: npx prettier "!package-lock.json" . --ignore-path .gitignore --check
 
-      - name: Build
-        run: npm run build
+            - name: Build
+              run: npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 "on":
   pull_request:
+  push:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,39 +1,39 @@
 name: Build
 
 on:
-    pull_request:
-    push:
-        branches:
-            - main
-    workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 permissions:
-    contents: read
+  contents: read
 
 concurrency:
-    group: build-${{ github.ref }}
-    cancel-in-progress: true
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    build:
-        name: Prettier and build
-        runs-on: ubuntu-latest
+  build:
+    name: Prettier and build
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version: 24
-                  cache: npm
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
 
-            - name: Install dependencies
-              run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-            - name: Check formatting
-              run: npx prettier "!package-lock.json" . --ignore-path .gitignore --check
+      - name: Check formatting
+        run: npm run format:check
 
-            - name: Build
-              run: npm run build
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ TypeScript и устройство Angular-приложений.
 - [CSS](src/pages/css/index.md)
 - [Рендеринг браузера и производительность (performance)](src/pages/web-platform/browser/index.md)
 - [HTTP, HTTPS и curl](src/pages/web-platform/http/index.md)
+- [Auth, SSO, OAuth 2.0 и OpenID Connect](src/pages/web-platform/auth/index.md)
 - [JavaScript](src/pages/javascript/index.md)
 - [TypeScript](src/pages/typescript/index.md)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ providers; поддерживаемые старые API помечены как
 #### 3.3 Продакшен в Angular
 
 - [Безопасность (Security)](src/pages/angular/index.md#security)
+- [Angular Auth, login/logout и router guards](src/pages/angular/auth/index.md)
 - [Производительность (Performance)](src/pages/angular/index.md#performance)
 - [SSR, hydration и SEO](src/pages/angular/index.md#ssr-hydration-и-seo)
 - [Angular PWA и Service Worker](src/pages/angular/index.md#angular-pwa-и-service-worker)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier !package-lock.json . --ignore-path .gitignore --write",
-    "format:check": "prettier !package-lock.json . --ignore-path .gitignore --check"
+    "format:check": "npm exec -- prettier !package-lock.json . --ignore-path .gitignore --check"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -1,49 +1,50 @@
 {
-    "name": "angular-ru-interview-questions",
-    "version": "1.0.0",
-    "private": true,
-    "description": "Вопросы подготовлены непосредственно для того, чтобы определить уровень разработчика, насколько глубоко, поверхностно или сносно он знает Angular. Вопросы для собеседования на знание JavaScript или Web-стека хорошо освещены в других местах, поэтому ниже будет добавлен список ресурсов по этой теме:",
-    "homepage": "https://github.com/Angular-RU/angular-ru-interview-questions#readme",
-    "bugs": {
-        "url": "https://github.com/Angular-RU/angular-ru-interview-questions/issues"
-    },
-    "workspaces": ["apps/*/*", "apps/*/*/*"],
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/Angular-RU/angular-ru-interview-questions.git"
-    },
-    "type": "module",
-    "license": "MIT",
-    "author": "angular-ru@yandex.ru",
-    "scripts": {
-        "predev": "npm run prebuild",
-        "dev": "astro dev",
-        "prebuild": "npm run build:public --workspaces --if-present",
-        "build": "astro build",
-        "preview": "astro preview",
-        "astro": "astro",
-        "format": "prettier !package-lock.json . --ignore-path .gitignore --write"
-    },
-    "dependencies": {
-        "@astrojs/markdown-remark": "^7.2.1",
-        "@types/node": "26.1.0",
-        "prettier": "3.8.4",
-        "rehype-raw": "^7.0.0",
-        "tsx": "4.20.6"
-    },
-    "devDependencies": {
-        "prettier-plugin-astro": "0.14.1",
-        "@astrojs/react": "6.0.1",
-        "@tailwindcss/vite": "4.3.2",
-        "@types/react": "19.2.17",
-        "@types/react-dom": "19.2.3",
-        "astro": "7.0.6",
-        "highlight.js": "11.11.1",
-        "markdown-it": "14.2.0",
-        "markdown-it-anchor": "9.2.0",
-        "react": "19.2.7",
-        "react-dom": "19.2.7",
-        "sharp": "0.35.3",
-        "tailwindcss": "4.3.2"
-    }
+  "name": "angular-ru-interview-questions",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Вопросы подготовлены непосредственно для того, чтобы определить уровень разработчика, насколько глубоко, поверхностно или сносно он знает Angular. Вопросы для собеседования на знание JavaScript или Web-стека хорошо освещены в других местах, поэтому ниже будет добавлен список ресурсов по этой теме:",
+  "homepage": "https://github.com/Angular-RU/angular-ru-interview-questions#readme",
+  "bugs": {
+    "url": "https://github.com/Angular-RU/angular-ru-interview-questions/issues"
+  },
+  "workspaces": ["apps/*/*", "apps/*/*/*"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Angular-RU/angular-ru-interview-questions.git"
+  },
+  "type": "module",
+  "license": "MIT",
+  "author": "angular-ru@yandex.ru",
+  "scripts": {
+    "predev": "npm run prebuild",
+    "dev": "astro dev",
+    "prebuild": "npm run build:public --workspaces --if-present",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro",
+    "format": "prettier !package-lock.json . --ignore-path .gitignore --write",
+    "format:check": "prettier !package-lock.json . --ignore-path .gitignore --check"
+  },
+  "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.1",
+    "@types/node": "26.1.0",
+    "prettier": "3.8.4",
+    "rehype-raw": "^7.0.0",
+    "tsx": "4.20.6"
+  },
+  "devDependencies": {
+    "prettier-plugin-astro": "0.14.1",
+    "@astrojs/react": "6.0.1",
+    "@tailwindcss/vite": "4.3.2",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "astro": "7.0.6",
+    "highlight.js": "11.11.1",
+    "markdown-it": "14.2.0",
+    "markdown-it-anchor": "9.2.0",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "sharp": "0.35.3",
+    "tailwindcss": "4.3.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,53 +1,50 @@
 {
-  "name": "angular-ru-interview-questions",
-  "version": "1.0.0",
-  "private": true,
-  "description": "Вопросы подготовлены непосредственно для того, чтобы определить уровень разработчика, насколько глубоко, поверхностно или сносно он знает Angular. Вопросы для собеседования на знание JavaScript или Web-стека хорошо освещены в других местах, поэтому ниже будет добавлен список ресурсов по этой теме:",
-  "homepage": "https://github.com/Angular-RU/angular-ru-interview-questions#readme",
-  "bugs": {
-    "url": "https://github.com/Angular-RU/angular-ru-interview-questions/issues"
-  },
-  "workspaces": [
-    "apps/*/*",
-    "apps/*/*/*"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Angular-RU/angular-ru-interview-questions.git"
-  },
-  "type": "module",
-  "license": "MIT",
-  "author": "angular-ru@yandex.ru",
-  "scripts": {
-    "predev": "npm run prebuild",
-    "dev": "astro dev",
-    "prebuild": "npm run build:public --workspaces --if-present",
-    "build": "astro build",
-    "preview": "astro preview",
-    "astro": "astro",
-    "format": "prettier \"!package-lock.json\" . --ignore-path .gitignore --write",
-    "format:check": "prettier \"!package-lock.json\" . --ignore-path .gitignore --check"
-  },
-  "dependencies": {
-    "@astrojs/markdown-remark": "^7.2.1",
-    "@types/node": "26.1.0",
-    "prettier": "3.8.4",
-    "rehype-raw": "^7.0.0",
-    "tsx": "4.20.6"
-  },
-  "devDependencies": {
-    "prettier-plugin-astro": "0.14.1",
-    "@astrojs/react": "6.0.1",
-    "@tailwindcss/vite": "4.3.2",
-    "@types/react": "19.2.17",
-    "@types/react-dom": "19.2.3",
-    "astro": "7.0.6",
-    "highlight.js": "11.11.1",
-    "markdown-it": "14.2.0",
-    "markdown-it-anchor": "9.2.0",
-    "react": "19.2.7",
-    "react-dom": "19.2.7",
-    "sharp": "0.35.3",
-    "tailwindcss": "4.3.2"
-  }
+    "name": "angular-ru-interview-questions",
+    "version": "1.0.0",
+    "private": true,
+    "description": "Вопросы подготовлены непосредственно для того, чтобы определить уровень разработчика, насколько глубоко, поверхностно или сносно он знает Angular. Вопросы для собеседования на знание JavaScript или Web-стека хорошо освещены в других местах, поэтому ниже будет добавлен список ресурсов по этой теме:",
+    "homepage": "https://github.com/Angular-RU/angular-ru-interview-questions#readme",
+    "bugs": {
+        "url": "https://github.com/Angular-RU/angular-ru-interview-questions/issues"
+    },
+    "workspaces": ["apps/*/*", "apps/*/*/*"],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Angular-RU/angular-ru-interview-questions.git"
+    },
+    "type": "module",
+    "license": "MIT",
+    "author": "angular-ru@yandex.ru",
+    "scripts": {
+        "predev": "npm run prebuild",
+        "dev": "astro dev",
+        "prebuild": "npm run build:public --workspaces --if-present",
+        "build": "astro build",
+        "preview": "astro preview",
+        "astro": "astro",
+        "format": "prettier \"!package-lock.json\" . --ignore-path .gitignore --write",
+        "format:check": "prettier \"!package-lock.json\" . --ignore-path .gitignore --check"
+    },
+    "dependencies": {
+        "@astrojs/markdown-remark": "^7.2.1",
+        "@types/node": "26.1.0",
+        "prettier": "3.8.4",
+        "rehype-raw": "^7.0.0",
+        "tsx": "4.20.6"
+    },
+    "devDependencies": {
+        "prettier-plugin-astro": "0.14.1",
+        "@astrojs/react": "6.0.1",
+        "@tailwindcss/vite": "4.3.2",
+        "@types/react": "19.2.17",
+        "@types/react-dom": "19.2.3",
+        "astro": "7.0.6",
+        "highlight.js": "11.11.1",
+        "markdown-it": "14.2.0",
+        "markdown-it-anchor": "9.2.0",
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
+        "sharp": "0.35.3",
+        "tailwindcss": "4.3.2"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "bugs": {
     "url": "https://github.com/Angular-RU/angular-ru-interview-questions/issues"
   },
-  "workspaces": ["apps/*/*", "apps/*/*/*"],
+  "workspaces": [
+    "apps/*/*",
+    "apps/*/*/*"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Angular-RU/angular-ru-interview-questions.git"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "format": "prettier !package-lock.json . --ignore-path .gitignore --write",
-    "format:check": "prettier !package-lock.json . --ignore-path .gitignore --check"
+    "format": "prettier \"!package-lock.json\" . --ignore-path .gitignore --write",
+    "format:check": "prettier \"!package-lock.json\" . --ignore-path .gitignore --check"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "format": "prettier !package-lock.json . --ignore-path .gitignore --write",
-    "format:check": "npm exec -- prettier !package-lock.json . --ignore-path .gitignore --check"
+    "format:check": "prettier !package-lock.json . --ignore-path .gitignore --check"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.1",

--- a/src/pages/angular/auth/index.md
+++ b/src/pages/angular/auth/index.md
@@ -31,10 +31,10 @@ order: 121
 Упрощенный пример `AuthService`:
 
 ```ts
-import {HttpClient} from '@angular/common/http';
-import {inject, Injectable, signal} from '@angular/core';
-import {Router} from '@angular/router';
-import {catchError, map, Observable, of, tap} from 'rxjs';
+import { HttpClient } from "@angular/common/http";
+import { inject, Injectable, signal } from "@angular/core";
+import { Router } from "@angular/router";
+import { catchError, map, Observable, of, tap } from "rxjs";
 
 interface LoginDto {
   readonly email: string;
@@ -47,7 +47,7 @@ interface User {
   readonly roles: readonly string[];
 }
 
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: "root" })
 export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
@@ -58,13 +58,13 @@ export class AuthService {
   readonly isAuthenticated = () => this.userState() !== null;
 
   login(dto: LoginDto): Observable<User> {
-    return this.http.post<User>('/api/auth/login', dto).pipe(
-      tap((user) => this.userState.set(user)),
-    );
+    return this.http
+      .post<User>("/api/auth/login", dto)
+      .pipe(tap((user) => this.userState.set(user)));
   }
 
   loadCurrentUser(): Observable<User | null> {
-    return this.http.get<User>('/api/auth/me').pipe(
+    return this.http.get<User>("/api/auth/me").pipe(
       tap((user) => this.userState.set(user)),
       catchError(() => {
         this.userState.set(null);
@@ -74,12 +74,13 @@ export class AuthService {
   }
 
   logout(): void {
-    this.http.post('/api/auth/logout', {}).pipe(
-      catchError(() => of(null)),
-    ).subscribe(() => {
-      this.userState.set(null);
-      void this.router.navigate(['/login']);
-    });
+    this.http
+      .post("/api/auth/logout", {})
+      .pipe(catchError(() => of(null)))
+      .subscribe(() => {
+        this.userState.set(null);
+        void this.router.navigate(["/login"]);
+      });
   }
 }
 ```
@@ -87,12 +88,12 @@ export class AuthService {
 Пример login component:
 
 ```ts
-import {Component, inject, signal} from '@angular/core';
-import {Router, ActivatedRoute} from '@angular/router';
-import {AuthService} from './auth.service';
+import { Component, inject, signal } from "@angular/core";
+import { Router, ActivatedRoute } from "@angular/router";
+import { AuthService } from "./auth.service";
 
 @Component({
-  selector: 'app-login-page',
+  selector: "app-login-page",
   template: `
     <form (ngSubmit)="submit()">
       <input name="email" type="email" autocomplete="email" />
@@ -111,13 +112,16 @@ export class LoginPageComponent {
   submit(): void {
     this.isLoading.set(true);
 
-    this.auth.login({email: 'demo@example.com', password: 'password'}).subscribe({
-      next: () => {
-        const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') ?? '/';
-        void this.router.navigateByUrl(returnUrl);
-      },
-      error: () => this.isLoading.set(false),
-    });
+    this.auth
+      .login({ email: "demo@example.com", password: "password" })
+      .subscribe({
+        next: () => {
+          const returnUrl =
+            this.route.snapshot.queryParamMap.get("returnUrl") ?? "/";
+          void this.router.navigateByUrl(returnUrl);
+        },
+        error: () => this.isLoading.set(false),
+      });
   }
 }
 ```
@@ -125,10 +129,10 @@ export class LoginPageComponent {
 Пример functional guard:
 
 ```ts
-import {inject} from '@angular/core';
-import {CanActivateFn, Router} from '@angular/router';
-import {map} from 'rxjs';
-import {AuthService} from './auth.service';
+import { inject } from "@angular/core";
+import { CanActivateFn, Router } from "@angular/router";
+import { map } from "rxjs";
+import { AuthService } from "./auth.service";
 
 export const authGuard: CanActivateFn = (route, state) => {
   const auth = inject(AuthService);
@@ -144,8 +148,8 @@ export const authGuard: CanActivateFn = (route, state) => {
         return true;
       }
 
-      return router.createUrlTree(['/login'], {
-        queryParams: {returnUrl: state.url},
+      return router.createUrlTree(["/login"], {
+        queryParams: { returnUrl: state.url },
       });
     }),
   );
@@ -155,18 +159,20 @@ export const authGuard: CanActivateFn = (route, state) => {
 Пример routes:
 
 ```ts
-import {Routes} from '@angular/router';
-import {authGuard} from './auth.guard';
+import { Routes } from "@angular/router";
+import { authGuard } from "./auth.guard";
 
 export const routes: Routes = [
   {
-    path: 'login',
-    loadComponent: () => import('./login-page.component').then((m) => m.LoginPageComponent),
+    path: "login",
+    loadComponent: () =>
+      import("./login-page.component").then((m) => m.LoginPageComponent),
   },
   {
-    path: 'account',
+    path: "account",
     canActivate: [authGuard],
-    loadComponent: () => import('./account-page.component').then((m) => m.AccountPageComponent),
+    loadComponent: () =>
+      import("./account-page.component").then((m) => m.AccountPageComponent),
   },
 ];
 ```
@@ -174,11 +180,11 @@ export const routes: Routes = [
 Кнопка logout:
 
 ```ts
-import {Component, inject} from '@angular/core';
-import {AuthService} from './auth.service';
+import { Component, inject } from "@angular/core";
+import { AuthService } from "./auth.service";
 
 @Component({
-  selector: 'app-header',
+  selector: "app-header",
   template: `<button type="button" (click)="logout()">Logout</button>`,
 })
 export class HeaderComponent {

--- a/src/pages/angular/auth/index.md
+++ b/src/pages/angular/auth/index.md
@@ -1,0 +1,208 @@
+---
+layout: ../../../layouts/Layout.astro
+title: Angular Auth, login/logout и router guards
+description: Вопросы и ответы
+category: Frontend
+kind: questions
+order: 121
+---
+
+## Angular Auth, login/logout и router guards
+
+### Login, logout и guards
+
+#### Middle+ or Senior
+
+<details>
+<summary>Как в Angular организовать login/logout и router guard для защищенных страниц?</summary><br>
+<table><tr><td>
+
+В Angular frontend обычно не "логинит пользователя сам", а вызывает backend или Identity Provider и хранит только
+клиентское состояние сессии: кто пользователь, идет ли проверка сессии, можно ли открыть protected route.
+
+Базовая схема:
+
+1. `AuthService` инкапсулирует login, logout, session state и запрос текущего пользователя.
+2. `HttpClient` отправляет запросы на backend auth endpoints.
+3. `CanActivateFn` guard не пускает на protected routes, если пользователь не авторизован.
+4. При logout frontend очищает локальное состояние и отправляет пользователя на login/public route.
+5. Backend все равно обязан проверять session/token и права на каждом защищенном endpoint.
+
+Упрощенный пример `AuthService`:
+
+```ts
+import {HttpClient} from '@angular/common/http';
+import {inject, Injectable, signal} from '@angular/core';
+import {Router} from '@angular/router';
+import {catchError, map, Observable, of, tap} from 'rxjs';
+
+interface LoginDto {
+  readonly email: string;
+  readonly password: string;
+}
+
+interface User {
+  readonly id: string;
+  readonly email: string;
+  readonly roles: readonly string[];
+}
+
+@Injectable({providedIn: 'root'})
+export class AuthService {
+  private readonly http = inject(HttpClient);
+  private readonly router = inject(Router);
+
+  private readonly userState = signal<User | null>(null);
+  readonly user = this.userState.asReadonly();
+
+  readonly isAuthenticated = () => this.userState() !== null;
+
+  login(dto: LoginDto): Observable<User> {
+    return this.http.post<User>('/api/auth/login', dto).pipe(
+      tap((user) => this.userState.set(user)),
+    );
+  }
+
+  loadCurrentUser(): Observable<User | null> {
+    return this.http.get<User>('/api/auth/me').pipe(
+      tap((user) => this.userState.set(user)),
+      catchError(() => {
+        this.userState.set(null);
+        return of(null);
+      }),
+    );
+  }
+
+  logout(): void {
+    this.http.post('/api/auth/logout', {}).pipe(
+      catchError(() => of(null)),
+    ).subscribe(() => {
+      this.userState.set(null);
+      void this.router.navigate(['/login']);
+    });
+  }
+}
+```
+
+Пример login component:
+
+```ts
+import {Component, inject, signal} from '@angular/core';
+import {Router, ActivatedRoute} from '@angular/router';
+import {AuthService} from './auth.service';
+
+@Component({
+  selector: 'app-login-page',
+  template: `
+    <form (ngSubmit)="submit()">
+      <input name="email" type="email" autocomplete="email" />
+      <input name="password" type="password" autocomplete="current-password" />
+      <button type="submit" [disabled]="isLoading()">Login</button>
+    </form>
+  `,
+})
+export class LoginPageComponent {
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
+
+  readonly isLoading = signal(false);
+
+  submit(): void {
+    this.isLoading.set(true);
+
+    this.auth.login({email: 'demo@example.com', password: 'password'}).subscribe({
+      next: () => {
+        const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') ?? '/';
+        void this.router.navigateByUrl(returnUrl);
+      },
+      error: () => this.isLoading.set(false),
+    });
+  }
+}
+```
+
+Пример functional guard:
+
+```ts
+import {inject} from '@angular/core';
+import {CanActivateFn, Router} from '@angular/router';
+import {map} from 'rxjs';
+import {AuthService} from './auth.service';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+
+  return auth.loadCurrentUser().pipe(
+    map((user) => {
+      if (user) {
+        return true;
+      }
+
+      return router.createUrlTree(['/login'], {
+        queryParams: {returnUrl: state.url},
+      });
+    }),
+  );
+};
+```
+
+Пример routes:
+
+```ts
+import {Routes} from '@angular/router';
+import {authGuard} from './auth.guard';
+
+export const routes: Routes = [
+  {
+    path: 'login',
+    loadComponent: () => import('./login-page.component').then((m) => m.LoginPageComponent),
+  },
+  {
+    path: 'account',
+    canActivate: [authGuard],
+    loadComponent: () => import('./account-page.component').then((m) => m.AccountPageComponent),
+  },
+];
+```
+
+Кнопка logout:
+
+```ts
+import {Component, inject} from '@angular/core';
+import {AuthService} from './auth.service';
+
+@Component({
+  selector: 'app-header',
+  template: `<button type="button" (click)="logout()">Logout</button>`,
+})
+export class HeaderComponent {
+  private readonly auth = inject(AuthService);
+
+  logout(): void {
+    this.auth.logout();
+  }
+}
+```
+
+Что важно сказать на собеседовании:
+
+- guard защищает route только на frontend и нужен в первую очередь для UX;
+- backend должен проверять сессию/token на каждом защищенном API-запросе;
+- при logout нужно очистить frontend state и попросить backend инвалидировать session/refresh token;
+- если используется cookie-based session, logout обычно очищает `HttpOnly` cookie через `Set-Cookie` с истекшим сроком;
+- если используется OIDC/SSO, logout может требовать redirect на Identity Provider logout endpoint;
+- после logout нельзя оставлять приватные данные в singleton services, caches, stores и component state;
+- `returnUrl` нужно валидировать, чтобы не сделать open redirect на внешний domain.
+
+Для production лучше не писать весь auth-flow руками, если команда использует OIDC/SSO provider. Обычно берут проверенную
+OIDC-библиотеку или backend-for-frontend подход, а Angular-код оставляют тонким слоем над login/logout/session state.
+
+</td></tr></table>
+
+</details>

--- a/src/pages/angular/auth/index.md
+++ b/src/pages/angular/auth/index.md
@@ -31,10 +31,10 @@ order: 121
 Упрощенный пример `AuthService`:
 
 ```ts
-import { HttpClient } from "@angular/common/http";
-import { inject, Injectable, signal } from "@angular/core";
-import { Router } from "@angular/router";
-import { catchError, map, Observable, of, tap } from "rxjs";
+import {HttpClient} from '@angular/common/http';
+import {inject, Injectable, signal} from '@angular/core';
+import {Router} from '@angular/router';
+import {catchError, map, Observable, of, tap} from 'rxjs';
 
 interface LoginDto {
   readonly email: string;
@@ -47,7 +47,7 @@ interface User {
   readonly roles: readonly string[];
 }
 
-@Injectable({ providedIn: "root" })
+@Injectable({providedIn: 'root'})
 export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
@@ -58,11 +58,11 @@ export class AuthService {
   readonly isAuthenticated = () => this.userState() !== null;
 
   login(dto: LoginDto): Observable<User> {
-    return this.http.post<User>("/api/auth/login", dto).pipe(tap((user) => this.userState.set(user)));
+    return this.http.post<User>('/api/auth/login', dto).pipe(tap((user) => this.userState.set(user)));
   }
 
   loadCurrentUser(): Observable<User | null> {
-    return this.http.get<User>("/api/auth/me").pipe(
+    return this.http.get<User>('/api/auth/me').pipe(
       tap((user) => this.userState.set(user)),
       catchError(() => {
         this.userState.set(null);
@@ -73,11 +73,11 @@ export class AuthService {
 
   logout(): void {
     this.http
-      .post("/api/auth/logout", {})
+      .post('/api/auth/logout', {})
       .pipe(catchError(() => of(null)))
       .subscribe(() => {
         this.userState.set(null);
-        void this.router.navigate(["/login"]);
+        void this.router.navigate(['/login']);
       });
   }
 }
@@ -86,17 +86,30 @@ export class AuthService {
 Пример login component:
 
 ```ts
-import { Component, inject, signal } from "@angular/core";
-import { Router, ActivatedRoute } from "@angular/router";
-import { AuthService } from "./auth.service";
+import {Component, inject, signal} from '@angular/core';
+import {Router, ActivatedRoute} from '@angular/router';
+import {AuthService} from './auth.service';
 
 @Component({
-  selector: "app-login-page",
+  selector: 'app-login-page',
   template: `
     <form (ngSubmit)="submit()">
-      <input name="email" type="email" autocomplete="email" />
-      <input name="password" type="password" autocomplete="current-password" />
-      <button type="submit" [disabled]="isLoading()">Login</button>
+      <input
+        name="email"
+        type="email"
+        autocomplete="email"
+      />
+      <input
+        name="password"
+        type="password"
+        autocomplete="current-password"
+      />
+      <button
+        type="submit"
+        [disabled]="isLoading()"
+      >
+        Login
+      </button>
     </form>
   `,
 })
@@ -110,9 +123,9 @@ export class LoginPageComponent {
   submit(): void {
     this.isLoading.set(true);
 
-    this.auth.login({ email: "demo@example.com", password: "password" }).subscribe({
+    this.auth.login({email: 'demo@example.com', password: 'password'}).subscribe({
       next: () => {
-        const returnUrl = this.route.snapshot.queryParamMap.get("returnUrl") ?? "/";
+        const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl') ?? '/';
         void this.router.navigateByUrl(returnUrl);
       },
       error: () => this.isLoading.set(false),
@@ -124,10 +137,10 @@ export class LoginPageComponent {
 Пример functional guard:
 
 ```ts
-import { inject } from "@angular/core";
-import { CanActivateFn, Router } from "@angular/router";
-import { map } from "rxjs";
-import { AuthService } from "./auth.service";
+import {inject} from '@angular/core';
+import {CanActivateFn, Router} from '@angular/router';
+import {map} from 'rxjs';
+import {AuthService} from './auth.service';
 
 export const authGuard: CanActivateFn = (route, state) => {
   const auth = inject(AuthService);
@@ -143,8 +156,8 @@ export const authGuard: CanActivateFn = (route, state) => {
         return true;
       }
 
-      return router.createUrlTree(["/login"], {
-        queryParams: { returnUrl: state.url },
+      return router.createUrlTree(['/login'], {
+        queryParams: {returnUrl: state.url},
       });
     }),
   );
@@ -154,18 +167,18 @@ export const authGuard: CanActivateFn = (route, state) => {
 Пример routes:
 
 ```ts
-import { Routes } from "@angular/router";
-import { authGuard } from "./auth.guard";
+import {Routes} from '@angular/router';
+import {authGuard} from './auth.guard';
 
 export const routes: Routes = [
   {
-    path: "login",
-    loadComponent: () => import("./login-page.component").then((m) => m.LoginPageComponent),
+    path: 'login',
+    loadComponent: () => import('./login-page.component').then((m) => m.LoginPageComponent),
   },
   {
-    path: "account",
+    path: 'account',
     canActivate: [authGuard],
-    loadComponent: () => import("./account-page.component").then((m) => m.AccountPageComponent),
+    loadComponent: () => import('./account-page.component').then((m) => m.AccountPageComponent),
   },
 ];
 ```
@@ -173,12 +186,19 @@ export const routes: Routes = [
 Кнопка logout:
 
 ```ts
-import { Component, inject } from "@angular/core";
-import { AuthService } from "./auth.service";
+import {Component, inject} from '@angular/core';
+import {AuthService} from './auth.service';
 
 @Component({
-  selector: "app-header",
-  template: `<button type="button" (click)="logout()">Logout</button>`,
+  selector: 'app-header',
+  template: `
+    <button
+      type="button"
+      (click)="logout()"
+    >
+      Logout
+    </button>
+  `,
 })
 export class HeaderComponent {
   private readonly auth = inject(AuthService);
@@ -199,8 +219,9 @@ export class HeaderComponent {
 - после logout нельзя оставлять приватные данные в singleton services, caches, stores и component state;
 - `returnUrl` нужно валидировать, чтобы не сделать open redirect на внешний domain.
 
-Для production лучше не писать весь auth-flow руками, если команда использует OIDC/SSO provider. Обычно берут проверенную
-OIDC-библиотеку или backend-for-frontend подход, а Angular-код оставляют тонким слоем над login/logout/session state.
+Для production лучше не писать весь auth-flow руками, если команда использует OIDC/SSO provider. Обычно берут
+проверенную OIDC-библиотеку или backend-for-frontend подход, а Angular-код оставляют тонким слоем над
+login/logout/session state.
 
 </td></tr></table>
 

--- a/src/pages/angular/auth/index.md
+++ b/src/pages/angular/auth/index.md
@@ -58,9 +58,7 @@ export class AuthService {
   readonly isAuthenticated = () => this.userState() !== null;
 
   login(dto: LoginDto): Observable<User> {
-    return this.http
-      .post<User>("/api/auth/login", dto)
-      .pipe(tap((user) => this.userState.set(user)));
+    return this.http.post<User>("/api/auth/login", dto).pipe(tap((user) => this.userState.set(user)));
   }
 
   loadCurrentUser(): Observable<User | null> {
@@ -112,16 +110,13 @@ export class LoginPageComponent {
   submit(): void {
     this.isLoading.set(true);
 
-    this.auth
-      .login({ email: "demo@example.com", password: "password" })
-      .subscribe({
-        next: () => {
-          const returnUrl =
-            this.route.snapshot.queryParamMap.get("returnUrl") ?? "/";
-          void this.router.navigateByUrl(returnUrl);
-        },
-        error: () => this.isLoading.set(false),
-      });
+    this.auth.login({ email: "demo@example.com", password: "password" }).subscribe({
+      next: () => {
+        const returnUrl = this.route.snapshot.queryParamMap.get("returnUrl") ?? "/";
+        void this.router.navigateByUrl(returnUrl);
+      },
+      error: () => this.isLoading.set(false),
+    });
   }
 }
 ```
@@ -165,14 +160,12 @@ import { authGuard } from "./auth.guard";
 export const routes: Routes = [
   {
     path: "login",
-    loadComponent: () =>
-      import("./login-page.component").then((m) => m.LoginPageComponent),
+    loadComponent: () => import("./login-page.component").then((m) => m.LoginPageComponent),
   },
   {
     path: "account",
     canActivate: [authGuard],
-    loadComponent: () =>
-      import("./account-page.component").then((m) => m.AccountPageComponent),
+    loadComponent: () => import("./account-page.component").then((m) => m.AccountPageComponent),
   },
 ];
 ```

--- a/src/pages/web-platform/auth/index.md
+++ b/src/pages/web-platform/auth/index.md
@@ -1,0 +1,72 @@
+---
+layout: ../../../layouts/Layout.astro
+title: Auth, SSO, OAuth 2.0 и OpenID Connect
+description: Вопросы и ответы
+category: Frontend
+kind: questions
+order: 65
+---
+
+## Auth, SSO, OAuth 2.0 и OpenID Connect
+
+### Auth и SSO
+
+#### Middle+ or Senior
+
+<details>
+<summary>Что такое SSO и как оно обычно работает в frontend-приложении?</summary><br>
+<table><tr><td>
+
+SSO, или Single Sign-On, — подход, при котором пользователь проходит аутентификацию один раз у доверенного Identity
+Provider, а затем получает доступ к нескольким приложениям без отдельного логина в каждом из них.
+
+Важно различать термины:
+
+- **authentication** — проверка, кто пользователь;
+- **authorization** — проверка, что пользователю разрешено делать;
+- **SSO** — пользовательский сценарий единого входа;
+- **OAuth 2.0** — протокол выдачи ограниченного доступа к ресурсам;
+- **OpenID Connect** — identity layer поверх OAuth 2.0, который добавляет `id_token` и стандартный способ узнать личность
+  пользователя;
+- **SAML** — XML-based протокол, который часто встречается в enterprise SSO.
+
+Типичный вариант для современного SPA — Authorization Code Flow with PKCE через OpenID Connect:
+
+1. Пользователь открывает приложение.
+2. Приложение понимает, что локальной сессии нет, и перенаправляет пользователя на Identity Provider.
+3. В redirect передаются `client_id`, `redirect_uri`, `scope`, `state`, `code_challenge` и другие параметры.
+4. Пользователь логинится у Identity Provider, например через пароль, MFA или корпоративную учетную запись.
+5. Identity Provider возвращает пользователя обратно в приложение с authorization code.
+6. Приложение или backend меняет code на tokens.
+7. Frontend получает состояние "пользователь вошел" и вызывает API с учетом выбранной session/token architecture.
+
+Упрощенный пример redirect:
+
+```text
+https://idp.example.com/authorize?
+  response_type=code&
+  client_id=spa-client&
+  redirect_uri=https://app.example.com/callback&
+  scope=openid%20profile%20email&
+  state=random-state&
+  code_challenge=pkce-code-challenge&
+  code_challenge_method=S256
+```
+
+Что важно сказать на собеседовании:
+
+- frontend не должен хранить `client_secret`, потому что SPA является public client;
+- `state` защищает от подмены/CSRF в login flow;
+- PKCE снижает риск перехвата authorization code;
+- `id_token` описывает аутентификацию пользователя, а `access_token` предназначен для доступа к API;
+- route guards на frontend улучшают UX, но настоящая authorization проверяется на backend;
+- tokens нельзя бездумно класть в `localStorage`: при XSS их сможет прочитать вредоносный script;
+- в enterprise чаще встречаются интеграции через OIDC или SAML, а конкретные детали зависят от Identity Provider.
+
+Практическая граница ответственности frontend-разработчика: правильно инициировать login/logout flow, обработать callback,
+не хранить секреты в bundle, аккуратно работать с tokens/session state, закрывать routes для UX и понимать, что backend
+обязан повторно проверять authentication, authorization, audience, issuer, expiry и scopes.
+
+</td></tr></table>
+
+</details>

--- a/src/pages/web-platform/auth/index.md
+++ b/src/pages/web-platform/auth/index.md
@@ -26,8 +26,8 @@ Provider, а затем получает доступ к нескольким п
 - **authorization** — проверка, что пользователю разрешено делать;
 - **SSO** — пользовательский сценарий единого входа;
 - **OAuth 2.0** — протокол выдачи ограниченного доступа к ресурсам;
-- **OpenID Connect** — identity layer поверх OAuth 2.0, который добавляет `id_token` и стандартный способ узнать личность
-  пользователя;
+- **OpenID Connect** — identity layer поверх OAuth 2.0, который добавляет `id_token` и стандартный способ узнать
+  личность пользователя;
 - **SAML** — XML-based протокол, который часто встречается в enterprise SSO.
 
 Типичный вариант для современного SPA — Authorization Code Flow with PKCE через OpenID Connect:
@@ -63,9 +63,9 @@ https://idp.example.com/authorize?
 - tokens нельзя бездумно класть в `localStorage`: при XSS их сможет прочитать вредоносный script;
 - в enterprise чаще встречаются интеграции через OIDC или SAML, а конкретные детали зависят от Identity Provider.
 
-Практическая граница ответственности frontend-разработчика: правильно инициировать login/logout flow, обработать callback,
-не хранить секреты в bundle, аккуратно работать с tokens/session state, закрывать routes для UX и понимать, что backend
-обязан повторно проверять authentication, authorization, audience, issuer, expiry и scopes.
+Практическая граница ответственности frontend-разработчика: правильно инициировать login/logout flow, обработать
+callback, не хранить секреты в bundle, аккуратно работать с tokens/session state, закрывать routes для UX и понимать,
+что backend обязан повторно проверять authentication, authorization, audience, issuer, expiry и scopes.
 
 </td></tr></table>
 


### PR DESCRIPTION
## Что изменено

- Добавлена новая Web Platform страница `Auth, SSO, OAuth 2.0 и OpenID Connect`.
- Добавлен вопрос: «Что такое SSO и как оно обычно работает в frontend-приложении?».
- Добавлена новая Angular страница `Angular Auth, login/logout и router guards`.
- Добавлен Angular-пример с `AuthService`, `login()`, `logout()`, `loadCurrentUser()`, functional `CanActivateFn` guard, redirect на `/login` и `returnUrl`.
- В ответе разобраны authentication vs authorization, SSO, OAuth 2.0, OpenID Connect, SAML, Authorization Code Flow with PKCE, `state`, `id_token`, `access_token`, хранение токенов и граница ответственности frontend/backend.
- Добавлены ссылки на новые страницы в `README.md`.

## Почему так

SSO вынесен в Web Platform/Auth, потому что это не Angular-specific тема. Angular-приложение только интегрируется с Identity Provider, а реальные проверки authentication/authorization остаются на backend/IdP.

Angular login/logout и router guard вынесены в отдельную Angular-страницу, потому что это уже framework-specific практика: как связать session state, routes, guards и redirect при logout.

## Проверка

- [ ] Проверить локальный build/docs preview