### PR TITLE
feat: add global Pagefind search and page metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,27 +12,26 @@
                 "apps/*/*",
                 "apps/*/*/*"
             ],
-            "dependencies": {
-                "@astrojs/markdown-remark": "^7.2.1",
-                "@types/node": "26.1.0",
-                "prettier": "3.8.4",
-                "rehype-raw": "^7.0.0",
-                "tsx": "4.20.6"
-            },
             "devDependencies": {
+                "@astrojs/markdown-remark": "7.2.1",
                 "@astrojs/react": "6.0.1",
                 "@tailwindcss/vite": "4.3.2",
+                "@types/node": "26.1.0",
                 "@types/react": "19.2.17",
                 "@types/react-dom": "19.2.3",
                 "astro": "7.0.6",
                 "highlight.js": "11.11.1",
                 "markdown-it": "14.2.0",
                 "markdown-it-anchor": "9.2.0",
+                "pagefind": "1.5.2",
+                "prettier": "3.8.4",
                 "prettier-plugin-astro": "0.14.1",
                 "react": "19.2.7",
                 "react-dom": "19.2.7",
+                "rehype-raw": "7.0.0",
                 "sharp": "0.35.3",
-                "tailwindcss": "4.3.2"
+                "tailwindcss": "4.3.2",
+                "tsx": "4.20.6"
             }
         },
         "apps/angular/mfe/movie-ticket": {
@@ -68,16 +67,13 @@
         },
         "apps/angular/mfe/movie-ticket/node_modules/@types/node": {
             "version": "20.19.43",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
-        },
-        "apps/angular/mfe/movie-ticket/node_modules/undici-types": {
-            "version": "6.21.0",
-            "dev": true,
-            "license": "MIT"
         },
         "apps/angular/mfe/movies": {
             "version": "0.0.0",
@@ -112,16 +108,13 @@
         },
         "apps/angular/mfe/movies/node_modules/@types/node": {
             "version": "20.19.43",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
-        },
-        "apps/angular/mfe/movies/node_modules/undici-types": {
-            "version": "6.21.0",
-            "dev": true,
-            "license": "MIT"
         },
         "apps/angular/mfe/ticket-availability": {
             "version": "0.0.0",
@@ -156,16 +149,13 @@
         },
         "apps/angular/mfe/ticket-availability/node_modules/@types/node": {
             "version": "20.19.43",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+            "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
-        },
-        "apps/angular/mfe/ticket-availability/node_modules/undici-types": {
-            "version": "6.21.0",
-            "dev": true,
-            "license": "MIT"
         },
         "apps/react/example1": {
             "version": "0.0.0",
@@ -183,45 +173,20 @@
                 "vite": "^8.1.1"
             }
         },
-        "apps/react/example1/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "apps/react/example1/node_modules/@types/node": {
-            "version": "24.13.2",
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.18.0"
             }
         },
-        "apps/react/example1/node_modules/@vitejs/plugin-react": {
-            "version": "6.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@rolldown/pluginutils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "peerDependencies": {
-                "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
-                "babel-plugin-react-compiler": "^1.0.0",
-                "vite": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@rolldown/plugin-babel": {
-                    "optional": true
-                },
-                "babel-plugin-react-compiler": {
-                    "optional": true
-                }
-            }
-        },
         "apps/react/example1/node_modules/undici-types": {
             "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
         },
@@ -241,45 +206,20 @@
                 "vite": "^8.1.1"
             }
         },
-        "apps/react/example2/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "apps/react/example2/node_modules/@types/node": {
-            "version": "24.13.2",
+            "version": "24.13.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+            "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.18.0"
             }
         },
-        "apps/react/example2/node_modules/@vitejs/plugin-react": {
-            "version": "6.0.3",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@rolldown/pluginutils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            },
-            "peerDependencies": {
-                "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
-                "babel-plugin-react-compiler": "^1.0.0",
-                "vite": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@rolldown/plugin-babel": {
-                    "optional": true
-                },
-                "babel-plugin-react-compiler": {
-                    "optional": true
-                }
-            }
-        },
         "apps/react/example2/node_modules/undici-types": {
             "version": "7.18.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+            "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
             "dev": true,
             "license": "MIT"
         },
@@ -287,7 +227,7 @@
             "version": "0.9.31",
             "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
             "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@algolia/abtesting": {
@@ -513,17 +453,17 @@
             }
         },
         "node_modules/@angular-architects/native-federation": {
-            "version": "22.0.4",
-            "resolved": "https://registry.npmjs.org/@angular-architects/native-federation/-/native-federation-22.0.4.tgz",
-            "integrity": "sha512-+WcgdlOKaVuNGtXku4kAYFJMA3Aavxw/FBvVobaVkxp/H7S5CoMaoyJcp+I+Gl+9u4d3aYCeHrOCQ8jUZjbHcA==",
+            "version": "22.0.6",
+            "resolved": "https://registry.npmjs.org/@angular-architects/native-federation/-/native-federation-22.0.6.tgz",
+            "integrity": "sha512-k4nkpZbUck8KmalJpxptaAOCPM+eb5MUOF3kWgXfuLdfJxZDPF34z+iIxlSHBmzIAVnnvgPDf4kzyGH8CLwE+A==",
             "license": "MIT",
             "dependencies": {
                 "@angular-devkit/architect": "^0.2200.0",
                 "@angular-devkit/core": "~22.0.0",
                 "@angular-devkit/schematics": "~22.0.0",
                 "@chialab/esbuild-plugin-commonjs": "^0.19.0",
-                "@softarc/native-federation": "^4.0.0",
-                "@softarc/native-federation-orchestrator": "^4.2.2",
+                "@softarc/native-federation": "^4.3.2",
+                "@softarc/native-federation-orchestrator": "^4.5.2",
                 "es-module-shims": "^2.8.0",
                 "esbuild": "^0.28.0",
                 "mrmime": "^2.0.1"
@@ -533,12 +473,12 @@
             }
         },
         "node_modules/@angular-devkit/architect": {
-            "version": "0.2200.5",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.5.tgz",
-            "integrity": "sha512-Fbki7xEx37gn8uH5AFOh0EmfGV4y5xag2fTv1vn6KxY/h33L02KuAjiUX3h2YmSjnYSc1dXto3Q5c4lWs/I5Zw==",
+            "version": "0.2200.8",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.8.tgz",
+            "integrity": "sha512-LFKK2v96nO0ESM9nftlCkTy+O/66AxNkwUpG+Q1er7LLNR2S8UReZnQ1/RhMkldCWxsmp2rQzdgHWnubaY/ZfA==",
             "license": "MIT",
             "dependencies": {
-                "@angular-devkit/core": "22.0.5",
+                "@angular-devkit/core": "22.0.8",
                 "rxjs": "7.8.2"
             },
             "bin": {
@@ -551,9 +491,9 @@
             }
         },
         "node_modules/@angular-devkit/core": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.5.tgz",
-            "integrity": "sha512-xxd3b9X0bbdGuYqDj1OgxtlGotrb/gsxQ5+4aqivWBHq4q/1RI8JfVB7gqcoYTvAfTq63Dwsk7Qd33hC4yJ1Wg==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.8.tgz",
+            "integrity": "sha512-Hnr4SCkxQM+xtq4uERC09qwTZpt97t4CwDZYzv/HbQA4pMYDfTxvIRHCyl+UHf4NbkC7ZVgyiab+KzTfuc609Q==",
             "license": "MIT",
             "dependencies": {
                 "ajv": "8.20.0",
@@ -577,25 +517,13 @@
                 }
             }
         },
-        "node_modules/@angular-devkit/core/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/@angular-devkit/schematics": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.5.tgz",
-            "integrity": "sha512-yKkImZuFLIbylmk1REyoW3EWQeqnr6qwtrzs4EPeaJgzjj+MZurq5slQ3fanK9lfX2q+W+dnSQFKBXHxlUGJ8Q==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.8.tgz",
+            "integrity": "sha512-9WjTKnW/5oIw4hNNcd0rSYtgHRrHKKAkG6+bdLqTCY68P2brO2yEJM2JjYtMYk/WSovknb0GxUP4n3dY3IxPug==",
             "license": "MIT",
             "dependencies": {
-                "@angular-devkit/core": "22.0.5",
+                "@angular-devkit/core": "22.0.8",
                 "jsonc-parser": "3.3.1",
                 "magic-string": "0.30.21",
                 "ora": "9.4.0",
@@ -608,16 +536,15 @@
             }
         },
         "node_modules/@angular/build": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.5.tgz",
-            "integrity": "sha512-uVXf1cSKTMDvpiP5x0X8h7D7dICHC2XsbmvRYtxdyTRy+zJduqtCdZTwnwmCrwIc5hOF+bmwa5p17P6XirYVfw==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/build/-/build-22.0.8.tgz",
+            "integrity": "sha512-QJVVTROVb27Ixk+RU4FSKwwyRbLdtNH20zFm1CwOKzA0wQHrWfxHTqlwMhnTOsOt5Cb3eX+6IjDXoGmAfJ81mA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "2.3.0",
-                "@angular-devkit/architect": "0.2200.5",
-                "@babel/core": "7.29.0",
-                "@babel/helper-annotate-as-pure": "7.27.3",
+                "@angular-devkit/architect": "0.2200.8",
+                "@babel/core": "7.29.7",
+                "@babel/helper-annotate-as-pure": "7.29.7",
                 "@babel/helper-split-export-declaration": "7.24.7",
                 "@inquirer/confirm": "6.0.12",
                 "@vitejs/plugin-basic-ssl": "2.3.0",
@@ -637,7 +564,7 @@
                 "semver": "7.7.4",
                 "source-map-support": "0.5.21",
                 "tinyglobby": "0.2.16",
-                "vite": "7.3.5",
+                "vite": "7.3.6",
                 "watchpack": "2.5.1"
             },
             "engines": {
@@ -656,7 +583,7 @@
                 "@angular/platform-browser": "^22.0.0",
                 "@angular/platform-server": "^22.0.0",
                 "@angular/service-worker": "^22.0.0",
-                "@angular/ssr": "^22.0.5",
+                "@angular/ssr": "^22.0.8",
                 "istanbul-lib-instrument": "^6.0.0",
                 "karma": "^6.4.0",
                 "less": "^4.2.0",
@@ -709,508 +636,13 @@
                 }
             }
         },
-        "node_modules/@angular/build/node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/android-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/android-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/android-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-            "cpu": [
-                "arm"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-            "cpu": [
-                "loong64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-            "cpu": [
-                "s390x"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/linux-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-            "cpu": [
-                "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/@esbuild/win32-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-            "cpu": [
-                "x64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@angular/build/node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/@angular/build/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@angular/build/node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "node_modules/@angular/build/node_modules/vite": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
-            "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
+            "version": "7.3.6",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+            "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
@@ -1278,61 +710,20 @@
                 }
             }
         },
-        "node_modules/@angular/build/node_modules/vite/node_modules/esbuild": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.7",
-                "@esbuild/android-arm": "0.27.7",
-                "@esbuild/android-arm64": "0.27.7",
-                "@esbuild/android-x64": "0.27.7",
-                "@esbuild/darwin-arm64": "0.27.7",
-                "@esbuild/darwin-x64": "0.27.7",
-                "@esbuild/freebsd-arm64": "0.27.7",
-                "@esbuild/freebsd-x64": "0.27.7",
-                "@esbuild/linux-arm": "0.27.7",
-                "@esbuild/linux-arm64": "0.27.7",
-                "@esbuild/linux-ia32": "0.27.7",
-                "@esbuild/linux-loong64": "0.27.7",
-                "@esbuild/linux-mips64el": "0.27.7",
-                "@esbuild/linux-ppc64": "0.27.7",
-                "@esbuild/linux-riscv64": "0.27.7",
-                "@esbuild/linux-s390x": "0.27.7",
-                "@esbuild/linux-x64": "0.27.7",
-                "@esbuild/netbsd-arm64": "0.27.7",
-                "@esbuild/netbsd-x64": "0.27.7",
-                "@esbuild/openbsd-arm64": "0.27.7",
-                "@esbuild/openbsd-x64": "0.27.7",
-                "@esbuild/openharmony-arm64": "0.27.7",
-                "@esbuild/sunos-x64": "0.27.7",
-                "@esbuild/win32-arm64": "0.27.7",
-                "@esbuild/win32-ia32": "0.27.7",
-                "@esbuild/win32-x64": "0.27.7"
-            }
-        },
         "node_modules/@angular/cli": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.5.tgz",
-            "integrity": "sha512-BYg2dWsbqdbpv3UVLNtDns1DoUbsROR8htPPIJEETj4Nfu7VF+g0nnM1CX2Ia+3002xtASgHp4YnRGQN/vAhWA==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-22.0.8.tgz",
+            "integrity": "sha512-kefbTsmf7sEmW5g3NIRvH0OrM18I1jjZHlB9KABgRQhsDfD/WgfLt6aSLJQeFDlAOs+ehDPzzOwd9l48wyBlFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@angular-devkit/architect": "0.2200.5",
-                "@angular-devkit/core": "22.0.5",
-                "@angular-devkit/schematics": "22.0.5",
+                "@angular-devkit/architect": "0.2200.8",
+                "@angular-devkit/core": "22.0.8",
+                "@angular-devkit/schematics": "22.0.8",
                 "@inquirer/prompts": "8.4.2",
                 "@listr2/prompt-adapter-inquirer": "4.2.3",
                 "@modelcontextprotocol/sdk": "1.29.0",
-                "@schematics/angular": "22.0.5",
+                "@schematics/angular": "22.0.8",
                 "@yarnpkg/lockfile": "1.1.0",
                 "algoliasearch": "5.52.0",
                 "ini": "6.0.0",
@@ -1354,33 +745,10 @@
                 "yarn": ">= 1.13.0"
             }
         },
-        "node_modules/@angular/cli/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@angular/cli/node_modules/zod": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
-            "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
         "node_modules/@angular/common": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.0.5.tgz",
-            "integrity": "sha512-8HUuQms6bVjjRBF9FScYzepjhesrsPAjJh8UcHaw9YdGwMSn2eUiLZj9V1PnPV9BVu0beBcnAhX50ceeldbcTg==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/common/-/common-22.0.8.tgz",
+            "integrity": "sha512-FnwkXndUgAyWk1/p5flMfocIUtuuneJ01mxC1FxRc5/bdWTyNVeQDsM9Lw4PEAPc0AHu//EnblegRq8o6LGdUQ==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -1389,14 +757,14 @@
                 "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
             },
             "peerDependencies": {
-                "@angular/core": "22.0.5",
+                "@angular/core": "22.0.8",
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
         "node_modules/@angular/compiler": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.0.5.tgz",
-            "integrity": "sha512-yGhbEBh2WU1kCubjBD+Eo5bwvZPR+zacDhyPao/PgopH0PiVETd4Iv1gK0ZAvg7XdImgzZfipJXKqTK4JbOFiQ==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-22.0.8.tgz",
+            "integrity": "sha512-ot7rvntfkZsPHmp8yl6PWUj/yG4e50X0+YeR7QYy/rEYKBiIg91w8GwjxSzaF4g5+bzJGDv7l/XnachKm0IySg==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -1406,11 +774,10 @@
             }
         },
         "node_modules/@angular/compiler-cli": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.0.5.tgz",
-            "integrity": "sha512-DR9kahfd5P/xrXbX8HJu8jBkkUZNqCZuMCod4lyo4a9MTOSKs2ltNU9VEDT7Qw++hDYowr37/lLfIzrvDEFPEQ==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-22.0.8.tgz",
+            "integrity": "sha512-shBqaUxMtqriv4UG2MHmYT8GSvDizI40mUFkOfeQ1yRJ2C9dk0TnWKPwjSO7o6bs6UiU6V8Y3uSWdmfCGVVZAA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/core": "7.29.7",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1429,7 +796,7 @@
                 "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
             },
             "peerDependencies": {
-                "@angular/compiler": "22.0.5",
+                "@angular/compiler": "22.0.8",
                 "typescript": ">=6.0 <6.1"
             },
             "peerDependenciesMeta": {
@@ -1438,28 +805,10 @@
                 }
             }
         },
-        "node_modules/@angular/compiler-cli/node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-            "license": "MIT"
-        },
-        "node_modules/@angular/compiler-cli/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/@angular/core": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.0.5.tgz",
-            "integrity": "sha512-8cc6CLC1u7kNHpUZA15tak0WPHAZTF16DPslXxDdWbw/WIlDGPsNdTW8Nsaeb/G45mLvBcMwcZpOC70R6iRzmA==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/core/-/core-22.0.8.tgz",
+            "integrity": "sha512-HagZZVzbtXd+ZhMb++k/HOtr/UTiBROHHH7xutgYgnSnPRXX0kCca5EQ02OZ/OCWfsMP5liSJDfwiePFULKA6Q==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -1468,7 +817,7 @@
                 "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
             },
             "peerDependencies": {
-                "@angular/compiler": "22.0.5",
+                "@angular/compiler": "22.0.8",
                 "rxjs": "^6.5.3 || ^7.4.0",
                 "zone.js": "~0.15.0 || ~0.16.0"
             },
@@ -1482,9 +831,9 @@
             }
         },
         "node_modules/@angular/forms": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.0.5.tgz",
-            "integrity": "sha512-kdmLo956pUMG6ZS0v9crAu16pEzBrz6i7rdfCsgI6A3lcfOWNTZLysMGHHiGGqfdP6LJR88ziHIEKrgtkCkK1A==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-22.0.8.tgz",
+            "integrity": "sha512-KlLJE8rgziSBqCQy+cqCHPEQPGjJEY53i1vZbpnBoLXhnwswLJ3O0c76RHNpIrlrvr9v4p3b2/LxSE8wQmdStg==",
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.0.0",
@@ -1495,16 +844,16 @@
                 "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
             },
             "peerDependencies": {
-                "@angular/common": "22.0.5",
-                "@angular/core": "22.0.5",
-                "@angular/platform-browser": "22.0.5",
+                "@angular/common": "22.0.8",
+                "@angular/core": "22.0.8",
+                "@angular/platform-browser": "22.0.8",
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
         "node_modules/@angular/platform-browser": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.0.5.tgz",
-            "integrity": "sha512-Jm0YQ0NsJl3vhzziO+BEmtW5AYIyI+jVGNJHs4nFKLqSPG7DWkBfx4EykHBN5pAR4NLwwaJyFgbgNE/epZJDZQ==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-22.0.8.tgz",
+            "integrity": "sha512-FllGHCayu5Dv82HAA9ORL04Xf+In9JGMbQ1Vn4QnhrAVxBz182vm+ZwszLzRDSAwmfeIjZDeK49tKAcqHR9XNg==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -1513,9 +862,9 @@
                 "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
             },
             "peerDependencies": {
-                "@angular/animations": "22.0.5",
-                "@angular/common": "22.0.5",
-                "@angular/core": "22.0.5"
+                "@angular/animations": "22.0.8",
+                "@angular/common": "22.0.8",
+                "@angular/core": "22.0.8"
             },
             "peerDependenciesMeta": {
                 "@angular/animations": {
@@ -1524,9 +873,9 @@
             }
         },
         "node_modules/@angular/platform-server": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-22.0.5.tgz",
-            "integrity": "sha512-uajbCaIbXXL9kqi1g3kKftjLBwMg01c6ymYmlXLpDeHBKSllsBzOjWsdtFubKpG4ehr+vUh+38eH4aPVVOCICA==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-22.0.8.tgz",
+            "integrity": "sha512-uG2/7vqb4hKnGVYN0khcA0W46AssKnYEa2l1kYoKcjz6JH/3ExHJohY3mgH5gwkpJCXT/xePv9S9AQsvwluh6w==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0",
@@ -1536,17 +885,17 @@
                 "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
             },
             "peerDependencies": {
-                "@angular/common": "22.0.5",
-                "@angular/compiler": "22.0.5",
-                "@angular/core": "22.0.5",
-                "@angular/platform-browser": "22.0.5",
+                "@angular/common": "22.0.8",
+                "@angular/compiler": "22.0.8",
+                "@angular/core": "22.0.8",
+                "@angular/platform-browser": "22.0.8",
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
         "node_modules/@angular/router": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.0.5.tgz",
-            "integrity": "sha512-1S5PCHicRQkQX4z/zjBu9VHMSoT9kOkWI0kuXuswiZtcFhK7kZbVvzrP/dBjc2YUg3AlsxS8iZY6fKFzj3/nBA==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/router/-/router-22.0.8.tgz",
+            "integrity": "sha512-9NO5K03QqfWMWWZ+Uu4WqBSLw/YAot918cBUFdgl6mTUOfoHi/xWO5pAt0SEpbXMHmWafJBdb99GRlAGybGSTg==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -1555,16 +904,16 @@
                 "node": "^22.22.3 || ^24.15.0 || >=26.0.0"
             },
             "peerDependencies": {
-                "@angular/common": "22.0.5",
-                "@angular/core": "22.0.5",
-                "@angular/platform-browser": "22.0.5",
+                "@angular/common": "22.0.8",
+                "@angular/core": "22.0.8",
+                "@angular/platform-browser": "22.0.8",
                 "rxjs": "^6.5.3 || ^7.4.0"
             }
         },
         "node_modules/@angular/ssr": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-22.0.5.tgz",
-            "integrity": "sha512-fK1P0M8+0BsVDp5NG/y3l3YHGNdyPRdtox7haLwxZu9nvra1Tra2yfwuURdnCwJKm30TUfdxR+cf5kkresA3tw==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@angular/ssr/-/ssr-22.0.8.tgz",
+            "integrity": "sha512-T3N0w40R7rQQ3oBhkbupNf0g6Vt1F1huQqNgdblImdOFAt05nXPlrwjV37MJ78vYpJnAjNSuGmqIfnm3OyflhQ==",
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.3.0"
@@ -1585,7 +934,7 @@
             "version": "5.1.11",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
             "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/generational-cache": "^1.0.1",
@@ -1602,7 +951,7 @@
             "version": "6.8.1",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
             "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1613,10 +962,10 @@
             }
         },
         "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-            "dev": true,
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "devOptional": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -1626,7 +975,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
             "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -1636,7 +985,7 @@
             "version": "2.3.9",
             "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@astrojs/compiler": {
@@ -1647,30 +996,30 @@
             "license": "MIT"
         },
         "node_modules/@astrojs/compiler-binding": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.0.tgz",
-            "integrity": "sha512-zlsOT5COD9hRwplJCgQhS21unxON5AKirf0vgt1ijXwuseYIaZdm2ZOpF8fsz+DY9EyXx+I/ukxtg7uoBep68A==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz",
+            "integrity": "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@astrojs/compiler-binding-darwin-arm64": "0.3.0",
-                "@astrojs/compiler-binding-darwin-x64": "0.3.0",
-                "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.0",
-                "@astrojs/compiler-binding-linux-arm64-musl": "0.3.0",
-                "@astrojs/compiler-binding-linux-x64-gnu": "0.3.0",
-                "@astrojs/compiler-binding-linux-x64-musl": "0.3.0",
-                "@astrojs/compiler-binding-wasm32-wasi": "0.3.0",
-                "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.0",
-                "@astrojs/compiler-binding-win32-x64-msvc": "0.3.0"
+                "@astrojs/compiler-binding-darwin-arm64": "0.3.1",
+                "@astrojs/compiler-binding-darwin-x64": "0.3.1",
+                "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1",
+                "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1",
+                "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1",
+                "@astrojs/compiler-binding-linux-x64-musl": "0.3.1",
+                "@astrojs/compiler-binding-wasm32-wasi": "0.3.1",
+                "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1",
+                "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1"
             }
         },
         "node_modules/@astrojs/compiler-binding-darwin-arm64": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.0.tgz",
-            "integrity": "sha512-3n0uu+uJpnCq8b4JFi3uGDsIisAvHctxSmH+cIO9Gbei1H1Y1QXaYboXyiWJugUmprr3OEYP7+LdodzpVFzLMQ==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz",
+            "integrity": "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==",
             "cpu": [
                 "arm64"
             ],
@@ -1685,9 +1034,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-darwin-x64": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.0.tgz",
-            "integrity": "sha512-scxNGKjOBydMo1QR4LtK0FMgh7ubQomJDv953nz2msQFkPKke/0FpPv/cQM0T/kuZdReZQFU8Oz3iOrP/6WHEg==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz",
+            "integrity": "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==",
             "cpu": [
                 "x64"
             ],
@@ -1702,13 +1051,16 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-arm64-gnu": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.0.tgz",
-            "integrity": "sha512-NZrWLolVUANmrnl0zrFK/Sx5Sock1gEUT49ALfMTTCA5Ya2ec/BoJXMIg4KgE+wZcrdXJ8e+WyEhM7YLk/FJkA==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz",
+            "integrity": "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1719,13 +1071,16 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-arm64-musl": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.0.tgz",
-            "integrity": "sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz",
+            "integrity": "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1736,13 +1091,16 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-x64-gnu": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.0.tgz",
-            "integrity": "sha512-Dr69VJYlnSfyL8gzELW6S4mE41P7TDPn1IKjwMnjdZ7+dxgJI50oMLFSk1LVe26bHmWB3ktuh8fDVK1THI9e9A==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz",
+            "integrity": "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1753,13 +1111,16 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-linux-x64-musl": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.0.tgz",
-            "integrity": "sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz",
+            "integrity": "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1770,9 +1131,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-wasm32-wasi": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.0.tgz",
-            "integrity": "sha512-U80tA1j8V6LjhiTZzVCtG4E8hrNVVNXDGV5fCgJ94q8FU9CPH+XwdDDhLzBybfWhKfyItXmQiZNRPTiPCYTpVg==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz",
+            "integrity": "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==",
             "cpu": [
                 "wasm32"
             ],
@@ -1787,9 +1148,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-win32-arm64-msvc": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.0.tgz",
-            "integrity": "sha512-CpY1RII2r1XMpOUVD1VR/F2wtuRsiOCkFULS10Khyj8/DFZMtxVuUCAWGw+CW2Ka0h6eP3Xc1CA+glFlvXMPxA==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz",
+            "integrity": "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1804,9 +1165,9 @@
             }
         },
         "node_modules/@astrojs/compiler-binding-win32-x64-msvc": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.0.tgz",
-            "integrity": "sha512-qmFbs769oeeGrRebAnCW7aBk8m71vf85W/dX/jddfx5Z06/w0wf7TZCfJPOX1Fld2t+4N+iXzfGEJG+zJQ+bzg==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz",
+            "integrity": "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==",
             "cpu": [
                 "x64"
             ],
@@ -1821,13 +1182,13 @@
             }
         },
         "node_modules/@astrojs/compiler-rs": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.0.tgz",
-            "integrity": "sha512-J2qEVHtIDjEM9TxwmwuebOGmZNwhKu/dR7P7qBpnJKGmBBX0vdweQ/4cEXhj8fBbWVUB5V12xWChri3CgKNULQ==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz",
+            "integrity": "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler-binding": "0.3.0"
+                "@astrojs/compiler-binding": "0.3.1"
             },
             "engines": {
                 "node": ">=22.12.0"
@@ -1837,6 +1198,7 @@
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.1.tgz",
             "integrity": "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.4",
@@ -1853,8 +1215,8 @@
             "version": "7.2.1",
             "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.2.1.tgz",
             "integrity": "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@astrojs/internal-helpers": "0.10.1",
                 "@astrojs/prism": "4.0.2",
@@ -1892,6 +1254,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.2.tgz",
             "integrity": "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "prismjs": "^1.30.0"
@@ -1921,6 +1284,34 @@
                 "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
                 "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@astrojs/react/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+            "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@astrojs/react/node_modules/@vitejs/plugin-react": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+            "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.29.0",
+                "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+                "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+                "@rolldown/pluginutils": "1.0.0-rc.3",
+                "@types/babel__core": "^7.20.5",
+                "react-refresh": "^0.18.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "peerDependencies": {
+                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/@astrojs/telemetry": {
@@ -1968,7 +1359,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -1994,6 +1384,21 @@
                 "url": "https://opencollective.com/babel"
             }
         },
+        "node_modules/@babel/core/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "license": "MIT"
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/generator": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -2011,12 +1416,12 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+            "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.3"
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -2036,6 +1441,15 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-globals": {
@@ -2235,7 +1649,7 @@
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
             "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "css-tree": "^3.0.0"
@@ -2245,91 +1659,110 @@
             }
         },
         "node_modules/@bruits/satteri-darwin-arm64": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.4.tgz",
-            "integrity": "sha512-W3MSUkr2mZRR8Stoe+lqNAyzQzRuFMU8WffV9IvFSxTok0LGWR0ZZQPLELU4QTRiUbhL2Y4VUP9vV7pj8rHjgg==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
+            "integrity": "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@bruits/satteri-darwin-x64": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.4.tgz",
-            "integrity": "sha512-DXOuuaE1lsv7mpk2mOvGrzqoEWEvOIZEO/fXVa7zfM23Iob+CBjBkRAMwpHA4pmZ3j6Gj7WJzPKw0kQ7w741AQ==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-x64/-/satteri-darwin-x64-0.9.5.tgz",
+            "integrity": "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@bruits/satteri-linux-arm64-gnu": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.4.tgz",
-            "integrity": "sha512-gJxU9rGGoqIznSEgEzpjxkry24jeHuMpoo1tCIAhHYh7WaD3j5F8zt3jmHxEaN1Uwa+K5+wFgIR2uIGOnMzEmw==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-gnu/-/satteri-linux-arm64-gnu-0.9.5.tgz",
+            "integrity": "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@bruits/satteri-linux-arm64-musl": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.4.tgz",
-            "integrity": "sha512-Wjzu9hmmAbfmDkBfPI1VdZygJtYz9uYZQnkEyrXi6S2JFi+2pXQ1A5irj38bqm0IZmWcTbk0cVG4NZnPdtVNJA==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-arm64-musl/-/satteri-linux-arm64-musl-0.9.5.tgz",
+            "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@bruits/satteri-linux-x64-gnu": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.4.tgz",
-            "integrity": "sha512-MR1Q+wMx65FQlbSV7cRqWW87Knp0zkoaIV55Dt+xZl028wJABXEPEEmG3670SLq7lVZvcGIDwCgSg2kCYxvRwA==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-gnu/-/satteri-linux-x64-gnu-0.9.5.tgz",
+            "integrity": "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@bruits/satteri-linux-x64-musl": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.4.tgz",
-            "integrity": "sha512-T4gxhXve3zyNAZesrXAd/rDZOGRkbfFIUFld4TGsw6BsjoIteCcDji6IMqeXyaWEVSykY2X8Eid2hr6aXGYAaw==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-linux-x64-musl/-/satteri-linux-x64-musl-0.9.5.tgz",
+            "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@bruits/satteri-wasm32-wasi": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.4.tgz",
-            "integrity": "sha512-/CEG8LUlpaBEnhFnYVn0UnlHFLs51UhrkJBUPDUXLzkadzAcnR88iRA/nOl7Zwhjb4WhfBV4p3P5qeOJMtH0iA==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-wasm32-wasi/-/satteri-wasm32-wasi-0.9.5.tgz",
+            "integrity": "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ==",
             "cpu": [
                 "wasm32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "dependencies": {
                 "@emnapi/core": "1.11.1",
@@ -2364,26 +1797,28 @@
             }
         },
         "node_modules/@bruits/satteri-win32-arm64-msvc": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.4.tgz",
-            "integrity": "sha512-E1ZPQbgCtFKiU7pFYVndynvY7ne4coeVDUgnVThErSFlJ2ceQCBZrfRTD1lzrIDy63Bbqo+g/cZY9duw+JYjIw==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-arm64-msvc/-/satteri-win32-arm64-msvc-0.9.5.tgz",
+            "integrity": "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@bruits/satteri-win32-x64-msvc": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.4.tgz",
-            "integrity": "sha512-5I7SiarsNdAUuhJb50CXJPTwr/ECVrBoU+fymoLjChK5fW//+srhY4lstcNTzgFRtQSYfVtm4OQZz16CVMeTeA==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@bruits/satteri-win32-x64-msvc/-/satteri-win32-x64-msvc-0.9.5.tgz",
+            "integrity": "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2456,12 +1891,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@chialab/estransform/node_modules/es-module-lexer": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-            "license": "MIT"
-        },
         "node_modules/@chialab/node-resolve": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@chialab/node-resolve/-/node-resolve-0.19.1.tgz",
@@ -2505,7 +1934,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
             "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2522,10 +1951,10 @@
             }
         },
         "node_modules/@csstools/css-calc": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
-            "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
-            "dev": true,
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+            "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2546,10 +1975,10 @@
             }
         },
         "node_modules/@csstools/css-color-parser": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
-            "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
-            "dev": true,
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+            "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2563,7 +1992,7 @@
             "license": "MIT",
             "dependencies": {
                 "@csstools/color-helpers": "^6.1.0",
-                "@csstools/css-calc": "^3.2.1"
+                "@csstools/css-calc": "^3.3.0"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -2577,7 +2006,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
             "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2589,7 +2018,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -2598,10 +2026,10 @@
             }
         },
         "node_modules/@csstools/css-syntax-patches-for-csstree": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
-            "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
-            "dev": true,
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+            "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2626,7 +2054,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
             "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -2638,7 +2066,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -2649,7 +2076,6 @@
             "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.2",
                 "tslib": "^2.4.0"
@@ -2661,7 +2087,6 @@
             "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -3096,7 +2521,7 @@
             "version": "1.15.1",
             "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
             "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -3258,6 +2683,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3275,6 +2703,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3292,6 +2723,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3309,6 +2743,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3326,6 +2763,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3343,6 +2783,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3360,6 +2803,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3377,6 +2823,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -3394,6 +2843,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3417,6 +2869,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3440,6 +2895,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3463,6 +2921,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3486,6 +2947,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3509,6 +2973,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3532,6 +2999,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3555,6 +3025,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -3896,7 +3369,6 @@
             "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^5.1.4",
                 "@inquirer/confirm": "^6.0.12",
@@ -4660,6 +4132,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4675,6 +4150,9 @@
             "integrity": "sha512-+2Rzdb3nTIYZ0YJF43qf2twhqOCkiSrHx2Pg6DJaCPYhhaxbLcdlV8hCRMHghQ+EtZQWGNcS2xF4KxBhSGeutg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4692,6 +4170,9 @@
             "cpu": [
                 "ppc64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4707,6 +4188,9 @@
             "integrity": "sha512-HU0nw9uD4FO/oGCCk409tCi5IzIZpH2agE6nN4fqpwVlCn5BOq0MS1dXGjXaG17JaAvrlpV5ZeyZwSon10XOXw==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -4724,6 +4208,9 @@
             "cpu": [
                 "s390x"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4740,6 +4227,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4755,6 +4245,9 @@
             "integrity": "sha512-xScCGnyj/oppsNPMnevsBe3pvNaoK7FGvMjT35riz9YdhB2WtTG47ZlbxtOLpjeO9SqqQ2J2igCmz6IJOD5JYw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -4924,9 +4417,9 @@
             }
         },
         "node_modules/@npmcli/agent/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -4944,19 +4437,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@npmcli/fs/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@npmcli/git": {
@@ -4990,26 +4470,13 @@
             }
         },
         "node_modules/@npmcli/git/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
-            }
-        },
-        "node_modules/@npmcli/git/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@npmcli/git/node_modules/which": {
@@ -5072,19 +4539,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/@npmcli/package-json/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@npmcli/promise-spawn": {
@@ -5161,9 +4615,9 @@
             "license": "MIT"
         },
         "node_modules/@oxc-parser/binding-android-arm-eabi": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.138.0.tgz",
-            "integrity": "sha512-hSYAD+F9W2Qh8SETMqBsQRx6YHvB4z+i/i36shlC7tfdZQauMs4vf3G/EQwKOkNlN7rkTiKINvsNmQb9q2MWcQ==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.141.0.tgz",
+            "integrity": "sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==",
             "cpu": [
                 "arm"
             ],
@@ -5177,9 +4631,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-android-arm64": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.138.0.tgz",
-            "integrity": "sha512-Ns5LLTp8cVyP8DsYqD482h0HE84xiGYRgtm7g4LtTinq209NAiMF768e/8r2NHaa0UMirS5mrT1m1VwiVmBi4Q==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.141.0.tgz",
+            "integrity": "sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==",
             "cpu": [
                 "arm64"
             ],
@@ -5193,9 +4647,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-arm64": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.138.0.tgz",
-            "integrity": "sha512-Yka0m4YhKUHBIZufafSLAeO+DUrfHPtNXBlZSj7DxshquIl41x/a+i/MbRnbOy8heuLiYU1STa6h0FAAzT7Pbw==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.141.0.tgz",
+            "integrity": "sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==",
             "cpu": [
                 "arm64"
             ],
@@ -5209,9 +4663,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-darwin-x64": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.138.0.tgz",
-            "integrity": "sha512-MWLUZZzmNRUqTWueZF27ncreaZ1wZ0gboWL2QMPxRQA2xgOmBPlGg2H9pAKJSPBlwEHcWa9TdWRiehAS+yls8w==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.141.0.tgz",
+            "integrity": "sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==",
             "cpu": [
                 "x64"
             ],
@@ -5225,9 +4679,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-freebsd-x64": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.138.0.tgz",
-            "integrity": "sha512-Vae5tzsrzZ/lCDVCZUMi/vzSiiHEgcOEfsyIfWOHmjZ2ji+gT+n96T757yX5/f7/7JIJuiannAHJKV5ARaF6ng==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.141.0.tgz",
+            "integrity": "sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==",
             "cpu": [
                 "x64"
             ],
@@ -5241,9 +4695,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.138.0.tgz",
-            "integrity": "sha512-qkU8wv5mYexrCw0X4DHFgxGbRScwGLIIKUkHXU7xXEiLoMnQzELak2gujxfa9GFrlEgPjbyLUDFHWm67Zs38ng==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.141.0.tgz",
+            "integrity": "sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==",
             "cpu": [
                 "arm"
             ],
@@ -5257,9 +4711,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.138.0.tgz",
-            "integrity": "sha512-3HgULIvoDV7h2ZfVYzxQwOSOJnAjMwYmyUBzndNuLRGgBNI549ED0P6AGmN9y2TnSvrwJ+Q8zqdxqssMnGXitA==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.141.0.tgz",
+            "integrity": "sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==",
             "cpu": [
                 "arm"
             ],
@@ -5273,11 +4727,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.138.0.tgz",
-            "integrity": "sha512-pIonbH2p0KLCwz4CNPCi0xGqci4numpMQDCLJwLfsrEky7NUuByKDFhCjzE0E7vR3aj/lBjyMoTskHBo/qSg8g==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.141.0.tgz",
+            "integrity": "sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5289,11 +4746,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.138.0.tgz",
-            "integrity": "sha512-cT5L1Xz/5m6Ga1hD3922gLc+fePOauJZJdApPTI/2Vu0EmYo62uHG9V5Dq65hhgU9TW10oDi2840y9cGdd7BIg==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.141.0.tgz",
+            "integrity": "sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5305,11 +4765,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.138.0.tgz",
-            "integrity": "sha512-hKy/vvejKk3LNE/FsRbekWejLa046//TnLWtSo7ur29NIsNbSIvnOVYIirSVC7fsd6NO8UFzwDdcoZfCyBvSBA==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.141.0.tgz",
+            "integrity": "sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5321,11 +4784,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.138.0.tgz",
-            "integrity": "sha512-bh6tjNGq0v0b9GAMu0pTv/YpTqepCFy0TIOtQHm8+41fZwLXTaB6xiEWVUSarNCXqc5kyzYcH6EOfwW1sJxJOw==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.141.0.tgz",
+            "integrity": "sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5337,11 +4803,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.138.0.tgz",
-            "integrity": "sha512-HhOkddcClSTtTxY10f/mACblKcQdxWy4lYYwX12G23j+S5eiJ5y1kpo1r7kKng+2bdnCBO+lCDWOVVc9kVl9+g==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.141.0.tgz",
+            "integrity": "sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5353,11 +4822,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.138.0.tgz",
-            "integrity": "sha512-5mi+wtbeJiEa4waGG88EcEGgJBBNJdDeIcayPPcrLNMXbCrgdtbb80q0Nrat7A8NglLUVzhuTAAp7K6PjmUO8Q==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.141.0.tgz",
+            "integrity": "sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5369,11 +4841,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.138.0.tgz",
-            "integrity": "sha512-ckbq3AMI7lI8AhQtE8KdqYRmzmzwKfCU12QN/PBKXO72PfWdvvZQN0hFShDX/XRNsPqjddLmvXaQMT3zfYtNlw==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.141.0.tgz",
+            "integrity": "sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5385,11 +4860,14 @@
             }
         },
         "node_modules/@oxc-parser/binding-linux-x64-musl": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.138.0.tgz",
-            "integrity": "sha512-JrCOzHO9BYEs5Xz5JHYBxSc/hYKxfXUj5QQb64sERSbkQot6+KEgMTOR2C9hLrhaqOui65OYcFyTTS+YxXDtnA==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.141.0.tgz",
+            "integrity": "sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -5401,9 +4879,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-openharmony-arm64": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.138.0.tgz",
-            "integrity": "sha512-eASMMfOOIfLHkWJRPSu8llByvVRM+c1M/lh18KjsjELM3y10+7B5iBbbrht9LdtsJXQ+mRuP/lJ7UWe3Ok3ehw==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.141.0.tgz",
+            "integrity": "sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==",
             "cpu": [
                 "arm64"
             ],
@@ -5417,48 +4895,27 @@
             }
         },
         "node_modules/@oxc-parser/binding-wasm32-wasi": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.138.0.tgz",
-            "integrity": "sha512-BnTCO87Iwc57NufXS7vcrkrmpN+daeCeYr1+/xgPT6HjwNs0lBmJYeFrcOs4WkNN8yscdd6Rc4FxWh3+59hAFw==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.141.0.tgz",
+            "integrity": "sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==",
             "cpu": [
                 "wasm32"
             ],
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "1.11.1",
-                "@emnapi/runtime": "1.11.1",
+                "@emnapi/core": "1.11.2",
+                "@emnapi/runtime": "1.11.2",
                 "@napi-rs/wasm-runtime": "^1.1.6"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
-        "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/core": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-            "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@oxc-parser/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-            "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.138.0.tgz",
-            "integrity": "sha512-+Zi47boD2wKNL0hOA47Vkwk6njMZ8sOsr4Geu/56EUtlooDh9crNOU41U6bXGS0UjC4Y72HtRA1iuB6qx1ARUw==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.141.0.tgz",
+            "integrity": "sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5472,9 +4929,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.138.0.tgz",
-            "integrity": "sha512-SYcV674Wi2WuoBefUFgf0PBMNlZe5IF0YZ0TnP7DK+EusMVpEWq6iz+7r64svjAb7vjthzlas0FUCSlz8YkqYg==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.141.0.tgz",
+            "integrity": "sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==",
             "cpu": [
                 "ia32"
             ],
@@ -5488,9 +4945,9 @@
             }
         },
         "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.138.0.tgz",
-            "integrity": "sha512-QZplnCxS4vPe4StAVBtvD2bW3pELlidf0Ek6iQ/HHiCjbEtrs5pFZZfLAoPhKLJyDzyxoGAdic9bSIYrJYTZcg==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.141.0.tgz",
+            "integrity": "sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==",
             "cpu": [
                 "x64"
             ],
@@ -5504,18 +4961,18 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
-            "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.141.0.tgz",
+            "integrity": "sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
             }
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.72.0.tgz",
-            "integrity": "sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.75.0.tgz",
+            "integrity": "sha512-lutovtFzJqlRaqpZrCqSSGaHZzl9nIxxpjLzhSRLunN6dCLylj0uzlCyQGaQDIys7rrv8kVXiFO+R4Zpn0bX7g==",
             "cpu": [
                 "arm"
             ],
@@ -5530,9 +4987,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.72.0.tgz",
-            "integrity": "sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.75.0.tgz",
+            "integrity": "sha512-hXI0hDgHkw4w5nfru72aG7y+2iQJmC4waH/KV6H/hbgA6yAP5jYNx0P9yug15Hs0tWl/+mda3Jjn/2gmDT48tw==",
             "cpu": [
                 "arm64"
             ],
@@ -5547,9 +5004,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.72.0.tgz",
-            "integrity": "sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.75.0.tgz",
+            "integrity": "sha512-D91BWbK/dMYfCcrghspPIuKs2D9LF4Z/OabVSQjw1AO6PWxArD7teDA48bm0ySFqWDaPVqmQRl5GMWNglTXyrQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5564,9 +5021,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.72.0.tgz",
-            "integrity": "sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.75.0.tgz",
+            "integrity": "sha512-02mpwzf12BonZ6PT0TuQoomvEh2kVl2WGBIKWezCyToIS+rYkQZ6GXnARBAl9A4Ovm2V+Xe7M4KretyqmmcnJQ==",
             "cpu": [
                 "x64"
             ],
@@ -5581,9 +5038,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.72.0.tgz",
-            "integrity": "sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.75.0.tgz",
+            "integrity": "sha512-qZJgLnDaBsiL5YESx2t/TZ8eXkL9fEkKoXEdzegROhlz9A0lgyGnZ0dAzJrh7LJAHQl2K9RdRueN2s/9N7+odg==",
             "cpu": [
                 "x64"
             ],
@@ -5598,9 +5055,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.72.0.tgz",
-            "integrity": "sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.75.0.tgz",
+            "integrity": "sha512-7XlaWA5BJD3XpCfrEqjEe6Zseeb14S7QGa304XfwKignRaKQ+eIj775BQ7nIslggWickl4IsPUFqJ+/gAyNHVg==",
             "cpu": [
                 "arm"
             ],
@@ -5615,9 +5072,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.72.0.tgz",
-            "integrity": "sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.75.0.tgz",
+            "integrity": "sha512-av6Tpv8yrcMMMOadOqENBhlsLRcGFXXwoQ0hzHhsmS9FJ4Wioy8we427GbcMe2XTxmL2e60T67H1Dyr3up+tAA==",
             "cpu": [
                 "arm"
             ],
@@ -5632,13 +5089,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.72.0.tgz",
-            "integrity": "sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.75.0.tgz",
+            "integrity": "sha512-WcUhd8fHT5plrA14lANevl+hOl815mVI5t2hU21oFWrZKFXIVV/Sr4rWQV0NzSvzBupbMLNc5ErEA6Ehxh5jMg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5649,13 +5109,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.72.0.tgz",
-            "integrity": "sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.75.0.tgz",
+            "integrity": "sha512-UWzp5wRHFe/ESO3+eEaxXsTkYTGLYjnTsi/I5neEacXSItQ6WNleapfOAeA4x2b8nyhJ4uQxqvtv9pHv8kWJtQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5666,13 +5129,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.72.0.tgz",
-            "integrity": "sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.75.0.tgz",
+            "integrity": "sha512-XEVRwGMLKCUKrvhLAz4F6AIh8MJrQVdSZtAmPpRZt9tGPsUnamPOcl3dS/ZQzJnar/Ymgc//+xho0L60Emzuxg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5683,13 +5149,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.72.0.tgz",
-            "integrity": "sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.75.0.tgz",
+            "integrity": "sha512-mAG4DUXqfLC8cTjMD2kt3jDmVzFREYtDyeLNdLdsCcBc4Zbl2EMuiFektGBilQwkNjYnMvCqJs55U+Hyb+b+jw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5700,13 +5169,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.72.0.tgz",
-            "integrity": "sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.75.0.tgz",
+            "integrity": "sha512-95hrAvriAlI+pekSomTFIn0+bawMDlDwTNVmdjsFusTHyL2JWh7TWvRNG/Lkim72uN8OiCcO9wcaC6omLP5E3w==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5717,13 +5189,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.72.0.tgz",
-            "integrity": "sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.75.0.tgz",
+            "integrity": "sha512-4b6f2+FrtruAESrCqIKcrarzfrSx+wk2QNcp+RT91/Prc+pMQMAfyZ1rG1c3tFQNl8Bc616tx40uNXyxNBRPbQ==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5734,13 +5209,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.72.0.tgz",
-            "integrity": "sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.75.0.tgz",
+            "integrity": "sha512-nshAhrUvXFUWOvqQ2soIw7HFNWvpvEV4o0cYSqPtzLiPF5gKyYTDOOTJ6Rn8g8K/iGvPIrbDA4v8+5MvnjJrrg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5751,13 +5229,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.72.0.tgz",
-            "integrity": "sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.75.0.tgz",
+            "integrity": "sha512-e4jNxLKnxLC6sYBQRxrI2pgIIxnmMtF8U/VwNYcjTT/CLS+spH624cYVnj07bTKwaEWT37/e025isOs6j/0xqA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -5768,9 +5249,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.72.0.tgz",
-            "integrity": "sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.75.0.tgz",
+            "integrity": "sha512-hZ2lH+1qLf/DiEP9UWuQTK2JWj/BgvMB4jhIV4SmNU1wfEiYYX4TynQyAZXx0j9X4qRYizAL042SKaV+8ynh4w==",
             "cpu": [
                 "arm64"
             ],
@@ -5785,9 +5266,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.72.0.tgz",
-            "integrity": "sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.75.0.tgz",
+            "integrity": "sha512-Ilj6PNzGDS3bCU0MSJH7Msh0NhH+T/mRp2shwg+q+GHeVlPwP5LEboW96aW+3kVKFk6zYZy1Xi5pZkqZh6X8KQ==",
             "cpu": [
                 "arm64"
             ],
@@ -5802,9 +5283,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.72.0.tgz",
-            "integrity": "sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.75.0.tgz",
+            "integrity": "sha512-QVit2nOEOiPhkmsrksPSkoGCdnZRNkspt8fwoYyP09te1VEbnSj4LAxua4rc8FKTmWkySVe05j8iz9GXYfF1AQ==",
             "cpu": [
                 "ia32"
             ],
@@ -5819,9 +5300,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.72.0.tgz",
-            "integrity": "sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.75.0.tgz",
+            "integrity": "sha512-DSxnNkBUAYARPwJtR12Ig3deWr8w0H997xP6jy33i+e0SyYJw8FKuz4+cZtpmPEhQmvlPJE3X/2vNxDmLkd/rA==",
             "cpu": [
                 "x64"
             ],
@@ -5835,6 +5316,104 @@
                 "node": "^20.19.0 || >=22.12.0"
             }
         },
+        "node_modules/@pagefind/darwin-arm64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+            "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@pagefind/darwin-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+            "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@pagefind/freebsd-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+            "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@pagefind/linux-arm64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+            "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@pagefind/linux-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+            "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@pagefind/windows-arm64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+            "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@pagefind/windows-x64": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+            "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@parcel/source-map": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.1.1.tgz",
@@ -5847,22 +5426,10 @@
                 "node": "^12.18.3 || >=14"
             }
         },
-        "node_modules/@parcel/source-map/node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-            "license": "Apache-2.0",
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/@parcel/watcher": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-            "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+            "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -5870,7 +5437,7 @@
                 "detect-libc": "^2.0.3",
                 "is-glob": "^4.0.3",
                 "node-addon-api": "^7.0.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">= 10.0.0"
@@ -5880,25 +5447,24 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "@parcel/watcher-android-arm64": "2.5.6",
-                "@parcel/watcher-darwin-arm64": "2.5.6",
-                "@parcel/watcher-darwin-x64": "2.5.6",
-                "@parcel/watcher-freebsd-x64": "2.5.6",
-                "@parcel/watcher-linux-arm-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm-musl": "2.5.6",
-                "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-                "@parcel/watcher-linux-arm64-musl": "2.5.6",
-                "@parcel/watcher-linux-x64-glibc": "2.5.6",
-                "@parcel/watcher-linux-x64-musl": "2.5.6",
-                "@parcel/watcher-win32-arm64": "2.5.6",
-                "@parcel/watcher-win32-ia32": "2.5.6",
-                "@parcel/watcher-win32-x64": "2.5.6"
+                "@parcel/watcher-android-arm64": "2.6.0",
+                "@parcel/watcher-darwin-arm64": "2.6.0",
+                "@parcel/watcher-darwin-x64": "2.6.0",
+                "@parcel/watcher-freebsd-x64": "2.6.0",
+                "@parcel/watcher-linux-arm-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm-musl": "2.6.0",
+                "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+                "@parcel/watcher-linux-arm64-musl": "2.6.0",
+                "@parcel/watcher-linux-x64-glibc": "2.6.0",
+                "@parcel/watcher-linux-x64-musl": "2.6.0",
+                "@parcel/watcher-win32-arm64": "2.6.0",
+                "@parcel/watcher-win32-x64": "2.6.0"
             }
         },
         "node_modules/@parcel/watcher-android-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-            "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+            "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
             "cpu": [
                 "arm64"
             ],
@@ -5916,9 +5482,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-            "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+            "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
             "cpu": [
                 "arm64"
             ],
@@ -5936,9 +5502,9 @@
             }
         },
         "node_modules/@parcel/watcher-darwin-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-            "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+            "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
             "cpu": [
                 "x64"
             ],
@@ -5956,9 +5522,9 @@
             }
         },
         "node_modules/@parcel/watcher-freebsd-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-            "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+            "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
             "cpu": [
                 "x64"
             ],
@@ -5976,11 +5542,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-            "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+            "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -5996,11 +5565,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-            "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+            "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6016,11 +5588,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-            "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+            "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6036,11 +5611,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-arm64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-            "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+            "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6056,11 +5634,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-glibc": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-            "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+            "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6076,11 +5657,14 @@
             }
         },
         "node_modules/@parcel/watcher-linux-x64-musl": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-            "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+            "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6096,31 +5680,11 @@
             }
         },
         "node_modules/@parcel/watcher-win32-arm64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-            "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+            "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
             "cpu": [
                 "arm64"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            }
-        },
-        "node_modules/@parcel/watcher-win32-ia32": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-            "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-            "cpu": [
-                "ia32"
             ],
             "license": "MIT",
             "optional": true,
@@ -6136,9 +5700,9 @@
             }
         },
         "node_modules/@parcel/watcher-win32-x64": {
-            "version": "2.5.6",
-            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-            "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+            "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
             "cpu": [
                 "x64"
             ],
@@ -6155,6 +5719,16 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/@parcel/watcher/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/@parcel/watcher/node_modules/node-addon-api": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -6163,9 +5737,9 @@
             "optional": true
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
-            "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+            "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
             "cpu": [
                 "arm64"
             ],
@@ -6179,9 +5753,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
-            "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+            "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
             "cpu": [
                 "arm64"
             ],
@@ -6195,9 +5769,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
-            "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+            "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
             "cpu": [
                 "x64"
             ],
@@ -6211,9 +5785,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
-            "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+            "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
             "cpu": [
                 "x64"
             ],
@@ -6227,9 +5801,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
-            "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+            "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
             "cpu": [
                 "arm"
             ],
@@ -6243,11 +5817,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
-            "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+            "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6259,11 +5836,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
-            "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+            "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6275,11 +5855,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
-            "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+            "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6291,11 +5874,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
-            "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+            "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6307,11 +5893,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
-            "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+            "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -6323,11 +5912,14 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
-            "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+            "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6339,9 +5931,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
-            "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+            "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
             "cpu": [
                 "arm64"
             ],
@@ -6355,9 +5947,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
-            "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+            "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
             "cpu": [
                 "wasm32"
             ],
@@ -6394,9 +5986,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
-            "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+            "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
             "cpu": [
                 "arm64"
             ],
@@ -6410,9 +6002,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
-            "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+            "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
             "cpu": [
                 "x64"
             ],
@@ -6426,10 +6018,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.3",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-            "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-            "dev": true,
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
             "license": "MIT"
         },
         "node_modules/@rollup/pluginutils": {
@@ -6540,6 +6131,9 @@
             "cpu": [
                 "arm"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6552,6 +6146,9 @@
             "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
             "cpu": [
                 "arm"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6566,6 +6163,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6578,6 +6178,9 @@
             "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6592,6 +6195,9 @@
             "cpu": [
                 "loong64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6604,6 +6210,9 @@
             "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
             "cpu": [
                 "loong64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6618,6 +6227,9 @@
             "cpu": [
                 "ppc64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6630,6 +6242,9 @@
             "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
             "cpu": [
                 "ppc64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6644,6 +6259,9 @@
             "cpu": [
                 "riscv64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6656,6 +6274,9 @@
             "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
             "cpu": [
                 "riscv64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6670,6 +6291,9 @@
             "cpu": [
                 "s390x"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6683,6 +6307,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -6695,6 +6322,9 @@
             "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -6781,14 +6411,14 @@
             ]
         },
         "node_modules/@schematics/angular": {
-            "version": "22.0.5",
-            "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.5.tgz",
-            "integrity": "sha512-e+1Ob5Kxt9QH2Gige0Bl56CXclG819RMl5Fso3kwO58+9AQnR2QxvjbetB7LDRl+YEG3TXCE4s3vdrV4gqRRAQ==",
+            "version": "22.0.8",
+            "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-22.0.8.tgz",
+            "integrity": "sha512-zD2WLe15SoKYyBZH1GTLLaVABNNObHkH4soQqXb9agN6zkrpE0naeWaBSFSWD+95VKCiMZl8LkiOXvK+6b8S6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@angular-devkit/core": "22.0.5",
-                "@angular-devkit/schematics": "22.0.5",
+                "@angular-devkit/core": "22.0.8",
+                "@angular-devkit/schematics": "22.0.8",
                 "jsonc-parser": "3.3.1",
                 "typescript": "6.0.3"
             },
@@ -6802,6 +6432,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.3.1.tgz",
             "integrity": "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/primitive": "4.3.1",
@@ -6818,6 +6449,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.3.1.tgz",
             "integrity": "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/types": "4.3.1",
@@ -6832,6 +6464,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.3.1.tgz",
             "integrity": "sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/types": "4.3.1",
@@ -6845,6 +6478,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.3.1.tgz",
             "integrity": "sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/types": "4.3.1"
@@ -6857,6 +6491,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.3.1.tgz",
             "integrity": "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/types": "4.3.1",
@@ -6871,6 +6506,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.3.1.tgz",
             "integrity": "sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/types": "4.3.1"
@@ -6883,6 +6519,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.3.1.tgz",
             "integrity": "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.2",
@@ -6896,6 +6533,7 @@
             "version": "10.0.2",
             "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
             "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@sigstore/bundle": {
@@ -6979,9 +6617,9 @@
             }
         },
         "node_modules/@softarc/native-federation": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@softarc/native-federation/-/native-federation-4.2.1.tgz",
-            "integrity": "sha512-yV7H21+iOZ1CqvzXo3BYPI612L/wUdICKRm9wlfc3eQXsKs2Ufy13W3qriTvSS/8o6xbC1gfJdHwh5/aPfK8pQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@softarc/native-federation/-/native-federation-4.3.2.tgz",
+            "integrity": "sha512-kRYaAWXNDtj5GURzs0yucPeQ4lODxgnyoUUoNqfM7H4ePIYZFOV+GLu8MkXSHokswOirjSmGAaSZZHkvCT/JIg==",
             "license": "MIT",
             "dependencies": {
                 "@softarc/sheriff-core": "^0.19.6",
@@ -6992,27 +6630,15 @@
             }
         },
         "node_modules/@softarc/native-federation-orchestrator": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/@softarc/native-federation-orchestrator/-/native-federation-orchestrator-4.4.1.tgz",
-            "integrity": "sha512-ETlmrUAjCqREy0ouT0rFlLHTDbLBtS4xG6YwfOLQPDgzRiWTzvPtT1S326sKVno4vSnJBXjcYSEL6JUMxJaBkg==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/@softarc/native-federation-orchestrator/-/native-federation-orchestrator-4.5.2.tgz",
+            "integrity": "sha512-3GM65AwdaDhqlbU9X7hg5TqF8FZfqHfIyKv2F28XIZwy1KPImVMKQUd28IUP7K8ROiFhMNltpwggGSF1xDZm/w==",
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.7.1"
             },
             "engines": {
                 "node": ">=22.14.0"
-            }
-        },
-        "node_modules/@softarc/native-federation-orchestrator/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/@softarc/sheriff-core": {
@@ -7166,6 +6792,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7183,6 +6812,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7200,6 +6832,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7217,6 +6852,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -7420,6 +7058,7 @@
             "version": "4.1.13",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
             "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/ms": "*"
@@ -7462,9 +7101,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-            "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+            "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7475,9 +7114,10 @@
             }
         },
         "node_modules/@types/hast": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+            "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
@@ -7495,7 +7135,8 @@
             "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
             "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/markdown-it": {
             "version": "14.1.2",
@@ -7513,6 +7154,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
             "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
@@ -7523,18 +7165,21 @@
             "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
             "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/ms": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/nlcst": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
             "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "*"
@@ -7544,11 +7189,18 @@
             "version": "26.1.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
             "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+            "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
+        },
+        "node_modules/@types/node/node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/@types/qs": {
             "version": "6.15.1",
@@ -7570,7 +7222,6 @@
             "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -7581,7 +7232,6 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -7611,12 +7261,14 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
             "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@ungap/structured-clone": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-            "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+            "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/@vitejs/plugin-basic-ssl": {
@@ -7632,37 +7284,42 @@
             }
         },
         "node_modules/@vitejs/plugin-react": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
-            "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+            "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/core": "^7.29.0",
-                "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-                "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-                "@rolldown/pluginutils": "1.0.0-rc.3",
-                "@types/babel__core": "^7.20.5",
-                "react-refresh": "^0.18.0"
+                "@rolldown/pluginutils": "^1.0.1"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
-                "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+                "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+                "babel-plugin-react-compiler": "^1.0.0",
+                "vite": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@rolldown/plugin-babel": {
+                    "optional": true
+                },
+                "babel-plugin-react-compiler": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
-            "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+            "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -7671,13 +7328,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
-            "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+            "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.9",
+                "@vitest/spy": "4.1.10",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -7708,9 +7365,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
-            "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+            "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -7721,13 +7378,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
-            "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+            "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.9",
+                "@vitest/utils": "4.1.10",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -7735,14 +7392,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
-            "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+            "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -7751,9 +7408,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
-            "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+            "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
             "devOptional": true,
             "license": "MIT",
             "funding": {
@@ -7761,19 +7418,26 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
-            "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+            "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.9",
+                "@vitest/pretty-format": "4.1.10",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
+        },
+        "node_modules/@vitest/utils/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/@yarnpkg/lockfile": {
             "version": "1.1.0",
@@ -7956,6 +7620,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
             "license": "Python-2.0"
         },
         "node_modules/aria-query": {
@@ -7972,6 +7637,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
             "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8073,18 +7739,12 @@
                 }
             }
         },
-        "node_modules/astro/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+        "node_modules/astro/node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
             "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
+            "license": "MIT"
         },
         "node_modules/axobject-query": {
             "version": "4.1.0",
@@ -8100,6 +7760,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
             "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8117,9 +7778,9 @@
             }
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.42",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-            "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+            "version": "2.11.1",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
+            "integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
@@ -8148,39 +7809,11 @@
                 "node": ">=18.0.0"
             }
         },
-        "node_modules/beasties/node_modules/css-select": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
-            "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "boolbase": "^1.0.0",
-                "css-what": "^7.0.0",
-                "domhandler": "^5.0.3",
-                "domutils": "^3.2.2",
-                "nth-check": "^2.1.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/beasties/node_modules/css-what": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
-            "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">= 6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
         "node_modules/bidi-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
             "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "require-from-string": "^2.0.2"
@@ -8230,16 +7863,16 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -8255,9 +7888,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.28.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-            "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+            "version": "4.28.7",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+            "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8273,12 +7906,11 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "baseline-browser-mapping": "^2.10.38",
-                "caniuse-lite": "^1.0.30001799",
-                "electron-to-chromium": "^1.5.376",
-                "node-releases": "^2.0.48",
+                "baseline-browser-mapping": "^2.10.44",
+                "caniuse-lite": "^1.0.30001806",
+                "electron-to-chromium": "^1.5.393",
+                "node-releases": "^2.0.51",
                 "update-browserslist-db": "^1.2.3"
             },
             "bin": {
@@ -8326,9 +7958,9 @@
             }
         },
         "node_modules/cacache/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -8365,9 +7997,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001800",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-            "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8388,6 +8020,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
             "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8420,6 +8053,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
             "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8430,6 +8064,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
             "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8440,6 +8075,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
             "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8458,7 +8094,6 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
             "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "readdirp": "^5.0.0"
             },
@@ -8615,6 +8250,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
             "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -8664,9 +8300,9 @@
             }
         },
         "node_modules/convert-source-map": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "license": "MIT"
         },
         "node_modules/cookie": {
@@ -8742,17 +8378,16 @@
             }
         },
         "node_modules/css-select": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-            "dev": true,
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-6.0.0.tgz",
+            "integrity": "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw==",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "boolbase": "^1.0.0",
-                "css-what": "^6.1.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "nth-check": "^2.0.1"
+                "css-what": "^7.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "nth-check": "^2.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
@@ -8762,9 +8397,8 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
             "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mdn-data": "2.27.1",
                 "source-map-js": "^1.2.1"
@@ -8774,10 +8408,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
-            "dev": true,
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-7.0.0.tgz",
+            "integrity": "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ==",
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">= 6"
@@ -8826,7 +8459,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
             "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@asamuzakjp/css-color": "^5.0.1",
@@ -8839,10 +8472,10 @@
             }
         },
         "node_modules/cssstyle/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-            "dev": true,
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+            "devOptional": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
@@ -8859,7 +8492,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
             "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "whatwg-mimetype": "^5.0.0",
@@ -8890,13 +8523,14 @@
             "version": "10.6.0",
             "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
             "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/decode-named-character-reference": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
             "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "character-entities": "^2.0.0"
@@ -8926,6 +8560,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
             "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -8939,18 +8574,21 @@
             "license": "MIT"
         },
         "node_modules/detect-libc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
             "license": "Apache-2.0",
+            "bin": {
+                "detect-libc": "bin/detect-libc.js"
+            },
             "engines": {
-                "node": ">=8"
+                "node": ">=0.10"
             }
         },
         "node_modules/devalue": {
-            "version": "5.8.1",
-            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-            "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+            "version": "5.8.2",
+            "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
+            "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
             "dev": true,
             "license": "MIT"
         },
@@ -8958,6 +8596,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
             "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dequal": "^2.0.0"
@@ -9063,9 +8702,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.387",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
-            "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
+            "version": "1.5.395",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
+            "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
@@ -9150,16 +8789,15 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
-            "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
-            "devOptional": true,
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
             "license": "MIT"
         },
         "node_modules/es-module-shims": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.8.1.tgz",
-            "integrity": "sha512-Ztg5TxFCT/ffzmSf/ginHIvSbsneH60X9tpaMBD/jWXHQZT1JJNj8tOO3mRmUT3ar7Qn3YK4EbM1SjJpN5dPBA==",
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.8.2.tgz",
+            "integrity": "sha512-Re3rc7Fu8zrN2lD6ExQo+9SS1o2hai0DSLuC/m6R09A84DTL6SSKO+/s3JzKN648yxxdjJfuyFLSpsgr5kb0KA==",
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
@@ -9234,6 +8872,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
             "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -9356,12 +8995,13 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-            "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+            "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "debug": "^4.4.3",
                 "ip-address": "^10.2.0"
             },
             "engines": {
@@ -9387,6 +9027,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
@@ -9427,9 +9068,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-            "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",
@@ -9684,6 +9325,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
             "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/glob": {
@@ -9786,6 +9428,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
             "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -9804,6 +9447,7 @@
             "version": "8.0.3",
             "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
             "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -9824,6 +9468,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
             "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
@@ -9837,6 +9482,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
             "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
@@ -9850,6 +9496,7 @@
             "version": "9.1.0",
             "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
             "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -9875,6 +9522,7 @@
             "version": "9.0.5",
             "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
             "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -9898,6 +9546,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
             "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -9917,6 +9566,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
             "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -9933,6 +9583,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
             "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0"
@@ -9946,6 +9597,7 @@
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
             "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -9970,12 +9622,11 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.27",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-            "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+            "version": "4.12.31",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+            "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=16.9.0"
             }
@@ -9994,9 +9645,9 @@
             }
         },
         "node_modules/hosted-git-info/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -10007,7 +9658,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
             "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@exodus/bytes": "^1.6.0"
@@ -10027,6 +9678,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
             "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -10095,7 +9747,7 @@
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
             "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.0",
@@ -10109,7 +9761,7 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
@@ -10320,6 +9972,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
             "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -10332,7 +9985,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
             "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/is-promise": {
@@ -10382,15 +10035,14 @@
             "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
         "node_modules/jose": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-            "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "version": "6.2.4",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+            "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -10407,6 +10059,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
             "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -10429,7 +10082,7 @@
             "version": "28.1.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
             "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@acemir/cssom": "^0.9.31",
@@ -10470,7 +10123,7 @@
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
             "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 14"
@@ -10480,7 +10133,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
             "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=20.19.0"
@@ -10493,7 +10146,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
             "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "^7.1.2",
@@ -10507,7 +10160,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
             "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "entities": "^8.0.0"
@@ -10584,7 +10237,6 @@
             "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
             "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
             "license": "MPL-2.0",
-            "peer": true,
             "dependencies": {
                 "detect-libc": "^2.0.3"
             },
@@ -10716,6 +10368,9 @@
             "cpu": [
                 "arm64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10735,6 +10390,9 @@
             "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
             "cpu": [
                 "arm64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -10756,6 +10414,9 @@
             "cpu": [
                 "x64"
             ],
+            "libc": [
+                "glibc"
+            ],
             "license": "MPL-2.0",
             "optional": true,
             "os": [
@@ -10775,6 +10436,9 @@
             "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
             "cpu": [
                 "x64"
+            ],
+            "libc": [
+                "musl"
             ],
             "license": "MPL-2.0",
             "optional": true,
@@ -10829,6 +10493,15 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/lightningcss/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/linkify-it": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
@@ -10854,7 +10527,6 @@
             "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
             "integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cli-truncate": "^5.2.0",
                 "eventemitter3": "^5.0.4",
@@ -10983,6 +10655,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
             "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -11059,7 +10732,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -11087,6 +10759,7 @@
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
             "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -11106,6 +10779,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
             "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11121,6 +10795,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
             "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11137,6 +10812,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
             "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11161,6 +10837,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
             "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mdast-util-from-markdown": "^2.0.0",
@@ -11180,6 +10857,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
             "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11197,6 +10875,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
             "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11214,6 +10893,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
             "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11229,6 +10909,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
             "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11246,6 +10927,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
             "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11262,6 +10944,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
             "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11276,6 +10959,7 @@
             "version": "13.2.1",
             "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
             "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -11297,6 +10981,7 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
             "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -11318,6 +11003,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
             "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0"
@@ -11331,13 +11017,13 @@
             "version": "2.27.1",
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
             "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "CC0-1.0"
         },
         "node_modules/mdurl": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+            "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
             "dev": true,
             "license": "MIT"
         },
@@ -11375,6 +11061,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
             "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11410,6 +11097,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
             "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11444,6 +11132,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
             "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -11464,6 +11153,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
             "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "micromark-util-character": "^2.0.0",
@@ -11480,6 +11170,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
             "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
@@ -11500,6 +11191,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
             "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
@@ -11518,6 +11210,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
             "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
@@ -11535,6 +11228,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
             "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "micromark-util-types": "^2.0.0"
@@ -11548,6 +11242,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
             "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
@@ -11565,6 +11260,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
             "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11586,6 +11282,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
             "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11608,6 +11305,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
             "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11628,6 +11326,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
             "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11650,6 +11349,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
             "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11672,6 +11372,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
             "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11692,6 +11393,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
             "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11711,6 +11413,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
             "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11732,6 +11435,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
             "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11752,6 +11456,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
             "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11771,6 +11476,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
             "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11793,6 +11499,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
             "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11809,6 +11516,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
             "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11825,6 +11533,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
             "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11844,6 +11553,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
             "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11863,6 +11573,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
             "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11884,6 +11595,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
             "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11906,6 +11618,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
             "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -11922,6 +11635,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
             "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "GitHub Sponsors",
@@ -12210,9 +11924,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "funding": [
                 {
                     "type": "github",
@@ -12250,6 +11964,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
             "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0"
@@ -12313,6 +12028,16 @@
                 "node-gyp-build-optional-packages-test": "build-test.js"
             }
         },
+        "node_modules/node-gyp-build-optional-packages/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "license": "Apache-2.0",
+            "optional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/node-gyp/node_modules/isexe": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
@@ -12321,19 +12046,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=20"
-            }
-        },
-        "node_modules/node-gyp/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/node-gyp/node_modules/undici": {
@@ -12370,9 +12082,9 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.50",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-            "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+            "version": "2.0.51",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+            "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -12430,19 +12142,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/npm-install-checks/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/npm-normalize-package-bin": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
@@ -12467,19 +12166,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/npm-package-arg/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/npm-packlist": {
@@ -12510,19 +12196,6 @@
             },
             "engines": {
                 "node": "^20.17.0 || >=22.9.0"
-            }
-        },
-        "node_modules/npm-pick-manifest/node_modules/semver": {
-            "version": "7.8.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/npm-registry-fetch": {
@@ -12579,9 +12252,9 @@
             }
         },
         "node_modules/obug": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-            "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+            "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
             "devOptional": true,
             "funding": [
                 "https://github.com/sponsors/sxzz",
@@ -12651,12 +12324,14 @@
             "version": "0.12.2",
             "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
             "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/oniguruma-to-es": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
             "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "oniguruma-parser": "^0.12.2",
@@ -12694,12 +12369,12 @@
             "optional": true
         },
         "node_modules/oxc-parser": {
-            "version": "0.138.0",
-            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.138.0.tgz",
-            "integrity": "sha512-c25lvfpZ2+WY1yk6NkP0X0RTQg0ZxgSVaZHDa7lt6fEe1jwZjPWkRWvTyZ1xyaM7roVJMdtRCfbhUj/d4ims3Q==",
+            "version": "0.141.0",
+            "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.141.0.tgz",
+            "integrity": "sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "^0.138.0"
+                "@oxc-project/types": "^0.141.0"
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
@@ -12708,32 +12383,32 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxc-parser/binding-android-arm-eabi": "0.138.0",
-                "@oxc-parser/binding-android-arm64": "0.138.0",
-                "@oxc-parser/binding-darwin-arm64": "0.138.0",
-                "@oxc-parser/binding-darwin-x64": "0.138.0",
-                "@oxc-parser/binding-freebsd-x64": "0.138.0",
-                "@oxc-parser/binding-linux-arm-gnueabihf": "0.138.0",
-                "@oxc-parser/binding-linux-arm-musleabihf": "0.138.0",
-                "@oxc-parser/binding-linux-arm64-gnu": "0.138.0",
-                "@oxc-parser/binding-linux-arm64-musl": "0.138.0",
-                "@oxc-parser/binding-linux-ppc64-gnu": "0.138.0",
-                "@oxc-parser/binding-linux-riscv64-gnu": "0.138.0",
-                "@oxc-parser/binding-linux-riscv64-musl": "0.138.0",
-                "@oxc-parser/binding-linux-s390x-gnu": "0.138.0",
-                "@oxc-parser/binding-linux-x64-gnu": "0.138.0",
-                "@oxc-parser/binding-linux-x64-musl": "0.138.0",
-                "@oxc-parser/binding-openharmony-arm64": "0.138.0",
-                "@oxc-parser/binding-wasm32-wasi": "0.138.0",
-                "@oxc-parser/binding-win32-arm64-msvc": "0.138.0",
-                "@oxc-parser/binding-win32-ia32-msvc": "0.138.0",
-                "@oxc-parser/binding-win32-x64-msvc": "0.138.0"
+                "@oxc-parser/binding-android-arm-eabi": "0.141.0",
+                "@oxc-parser/binding-android-arm64": "0.141.0",
+                "@oxc-parser/binding-darwin-arm64": "0.141.0",
+                "@oxc-parser/binding-darwin-x64": "0.141.0",
+                "@oxc-parser/binding-freebsd-x64": "0.141.0",
+                "@oxc-parser/binding-linux-arm-gnueabihf": "0.141.0",
+                "@oxc-parser/binding-linux-arm-musleabihf": "0.141.0",
+                "@oxc-parser/binding-linux-arm64-gnu": "0.141.0",
+                "@oxc-parser/binding-linux-arm64-musl": "0.141.0",
+                "@oxc-parser/binding-linux-ppc64-gnu": "0.141.0",
+                "@oxc-parser/binding-linux-riscv64-gnu": "0.141.0",
+                "@oxc-parser/binding-linux-riscv64-musl": "0.141.0",
+                "@oxc-parser/binding-linux-s390x-gnu": "0.141.0",
+                "@oxc-parser/binding-linux-x64-gnu": "0.141.0",
+                "@oxc-parser/binding-linux-x64-musl": "0.141.0",
+                "@oxc-parser/binding-openharmony-arm64": "0.141.0",
+                "@oxc-parser/binding-wasm32-wasi": "0.141.0",
+                "@oxc-parser/binding-win32-arm64-msvc": "0.141.0",
+                "@oxc-parser/binding-win32-ia32-msvc": "0.141.0",
+                "@oxc-parser/binding-win32-x64-msvc": "0.141.0"
             }
         },
         "node_modules/oxlint": {
-            "version": "1.72.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.72.0.tgz",
-            "integrity": "sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.75.0.tgz",
+            "integrity": "sha512-m9WzjRcRYA/uqIZDa9tclrieoPJ/ln1QYTKdFx6NUOs8uY5DiHlIwRQoCrHT6OM6O3ww3l2skY5gO7G7ZphE7g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -12746,28 +12421,28 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.72.0",
-                "@oxlint/binding-android-arm64": "1.72.0",
-                "@oxlint/binding-darwin-arm64": "1.72.0",
-                "@oxlint/binding-darwin-x64": "1.72.0",
-                "@oxlint/binding-freebsd-x64": "1.72.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.72.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.72.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.72.0",
-                "@oxlint/binding-linux-arm64-musl": "1.72.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.72.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.72.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.72.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.72.0",
-                "@oxlint/binding-linux-x64-gnu": "1.72.0",
-                "@oxlint/binding-linux-x64-musl": "1.72.0",
-                "@oxlint/binding-openharmony-arm64": "1.72.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.72.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.72.0",
-                "@oxlint/binding-win32-x64-msvc": "1.72.0"
+                "@oxlint/binding-android-arm-eabi": "1.75.0",
+                "@oxlint/binding-android-arm64": "1.75.0",
+                "@oxlint/binding-darwin-arm64": "1.75.0",
+                "@oxlint/binding-darwin-x64": "1.75.0",
+                "@oxlint/binding-freebsd-x64": "1.75.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.75.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.75.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.75.0",
+                "@oxlint/binding-linux-arm64-musl": "1.75.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.75.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.75.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.75.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.75.0",
+                "@oxlint/binding-linux-x64-gnu": "1.75.0",
+                "@oxlint/binding-linux-x64-musl": "1.75.0",
+                "@oxlint/binding-openharmony-arm64": "1.75.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.75.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.75.0",
+                "@oxlint/binding-win32-x64-msvc": "1.75.0"
             },
             "peerDependencies": {
-                "oxlint-tsgolint": ">=0.22.1",
+                "oxlint-tsgolint": ">=7.0.2001",
                 "vite-plus": "*"
             },
             "peerDependenciesMeta": {
@@ -12780,9 +12455,9 @@
             }
         },
         "node_modules/p-limit": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
-            "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.1.tgz",
+            "integrity": "sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12796,9 +12471,9 @@
             }
         },
         "node_modules/p-map": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-            "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+            "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12809,9 +12484,9 @@
             }
         },
         "node_modules/p-queue": {
-            "version": "9.3.1",
-            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.1.tgz",
-            "integrity": "sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==",
+            "version": "9.3.3",
+            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.3.tgz",
+            "integrity": "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -12839,9 +12514,9 @@
             }
         },
         "node_modules/package-manager-detector": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
-            "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+            "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
             "dev": true,
             "license": "MIT"
         },
@@ -12877,10 +12552,30 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/pagefind": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+            "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "pagefind": "lib/runner/bin.cjs"
+            },
+            "optionalDependencies": {
+                "@pagefind/darwin-arm64": "1.5.2",
+                "@pagefind/darwin-x64": "1.5.2",
+                "@pagefind/freebsd-x64": "1.5.2",
+                "@pagefind/linux-arm64": "1.5.2",
+                "@pagefind/linux-x64": "1.5.2",
+                "@pagefind/windows-arm64": "1.5.2",
+                "@pagefind/windows-x64": "1.5.2"
+            }
+        },
         "node_modules/parse-latin": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
             "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
@@ -12899,6 +12594,7 @@
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
             "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "entities": "^6.0.0"
@@ -12985,6 +12681,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
             "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=0.12"
@@ -13030,9 +12727,9 @@
             }
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -13070,9 +12767,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -13104,9 +12801,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.16",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-            "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+            "version": "8.5.22",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+            "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -13122,9 +12819,8 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -13168,6 +12864,7 @@
             "version": "3.8.4",
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
             "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -13198,6 +12895,7 @@
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
             "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -13227,6 +12925,7 @@
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
             "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -13250,7 +12949,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -13342,7 +13041,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
             "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13352,7 +13050,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
             "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -13393,6 +13090,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
             "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "regex-utilities": "^2.3.0"
@@ -13402,6 +13100,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
             "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "regex-utilities": "^2.3.0"
@@ -13411,12 +13110,14 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
             "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/rehype-raw": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
             "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -13432,6 +13133,7 @@
             "version": "10.0.1",
             "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
             "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -13447,6 +13149,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
             "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -13465,6 +13168,7 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
             "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -13481,6 +13185,7 @@
             "version": "11.1.2",
             "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
             "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/hast": "^3.0.0",
@@ -13498,6 +13203,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
             "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "retext": "^9.0.0",
@@ -13513,6 +13219,7 @@
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
             "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/mdast": "^4.0.0",
@@ -13537,6 +13244,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "devOptional": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -13562,6 +13270,7 @@
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
             "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
@@ -13578,6 +13287,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
             "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
@@ -13593,6 +13303,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
             "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
@@ -13608,6 +13319,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
             "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/nlcst": "^2.0.0",
@@ -13636,12 +13348,12 @@
             "license": "MIT"
         },
         "node_modules/rolldown": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
-            "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+            "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.138.0",
+                "@oxc-project/types": "=0.139.0",
                 "@rolldown/pluginutils": "^1.0.0"
             },
             "bin": {
@@ -13651,28 +13363,31 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.1.4",
-                "@rolldown/binding-darwin-arm64": "1.1.4",
-                "@rolldown/binding-darwin-x64": "1.1.4",
-                "@rolldown/binding-freebsd-x64": "1.1.4",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
-                "@rolldown/binding-linux-arm64-gnu": "1.1.4",
-                "@rolldown/binding-linux-arm64-musl": "1.1.4",
-                "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
-                "@rolldown/binding-linux-s390x-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-gnu": "1.1.4",
-                "@rolldown/binding-linux-x64-musl": "1.1.4",
-                "@rolldown/binding-openharmony-arm64": "1.1.4",
-                "@rolldown/binding-wasm32-wasi": "1.1.4",
-                "@rolldown/binding-win32-arm64-msvc": "1.1.4",
-                "@rolldown/binding-win32-x64-msvc": "1.1.4"
+                "@rolldown/binding-android-arm64": "1.1.5",
+                "@rolldown/binding-darwin-arm64": "1.1.5",
+                "@rolldown/binding-darwin-x64": "1.1.5",
+                "@rolldown/binding-freebsd-x64": "1.1.5",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+                "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+                "@rolldown/binding-linux-arm64-musl": "1.1.5",
+                "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+                "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-gnu": "1.1.5",
+                "@rolldown/binding-linux-x64-musl": "1.1.5",
+                "@rolldown/binding-openharmony-arm64": "1.1.5",
+                "@rolldown/binding-wasm32-wasi": "1.1.5",
+                "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+                "@rolldown/binding-win32-x64-msvc": "1.1.5"
             }
         },
-        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-            "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-            "license": "MIT"
+        "node_modules/rolldown/node_modules/@oxc-project/types": {
+            "version": "0.139.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+            "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
         },
         "node_modules/rollup": {
             "version": "4.60.2",
@@ -13790,7 +13505,6 @@
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
             "integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
                 "immutable": "^5.1.5",
@@ -13845,10 +13559,11 @@
             }
         },
         "node_modules/satteri": {
-            "version": "0.9.4",
-            "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.4.tgz",
-            "integrity": "sha512-BKob126Tay84diOZsnVNH/Q/c+3njPJTCad3w5zLKa6j8bVjxskPNHDtxrMwYK4bN/RlqUSdMnPwKY4k65EMOQ==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/satteri/-/satteri-0.9.5.tgz",
+            "integrity": "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/estree-jsx": "^1.0.5",
                 "@types/hast": "^3.0.4",
@@ -13856,15 +13571,15 @@
                 "@types/unist": "^3.0.3"
             },
             "optionalDependencies": {
-                "@bruits/satteri-darwin-arm64": "0.9.4",
-                "@bruits/satteri-darwin-x64": "0.9.4",
-                "@bruits/satteri-linux-arm64-gnu": "0.9.4",
-                "@bruits/satteri-linux-arm64-musl": "0.9.4",
-                "@bruits/satteri-linux-x64-gnu": "0.9.4",
-                "@bruits/satteri-linux-x64-musl": "0.9.4",
-                "@bruits/satteri-wasm32-wasi": "0.9.4",
-                "@bruits/satteri-win32-arm64-msvc": "0.9.4",
-                "@bruits/satteri-win32-x64-msvc": "0.9.4"
+                "@bruits/satteri-darwin-arm64": "0.9.5",
+                "@bruits/satteri-darwin-x64": "0.9.5",
+                "@bruits/satteri-linux-arm64-gnu": "0.9.5",
+                "@bruits/satteri-linux-arm64-musl": "0.9.5",
+                "@bruits/satteri-linux-x64-gnu": "0.9.5",
+                "@bruits/satteri-linux-x64-musl": "0.9.5",
+                "@bruits/satteri-wasm32-wasi": "0.9.5",
+                "@bruits/satteri-win32-arm64-msvc": "0.9.5",
+                "@bruits/satteri-win32-x64-msvc": "0.9.5"
             }
         },
         "node_modules/sax": {
@@ -13881,7 +13596,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
             "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-            "dev": true,
+            "devOptional": true,
             "license": "ISC",
             "dependencies": {
                 "xmlchars": "^2.2.0"
@@ -13897,12 +13612,15 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/send": {
@@ -14006,6 +13724,16 @@
                 }
             }
         },
+        "node_modules/sharp/node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/sharp/node_modules/semver": {
             "version": "7.8.5",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -14046,6 +13774,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.3.1.tgz",
             "integrity": "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@shikijs/core": "4.3.1",
@@ -14208,6 +13937,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
             "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">= 18"
@@ -14297,6 +14027,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
             "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -14358,9 +14089,9 @@
             }
         },
         "node_modules/std-env": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+            "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -14377,9 +14108,9 @@
             }
         },
         "node_modules/string-width": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-            "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+            "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
             "license": "MIT",
             "dependencies": {
                 "get-east-asian-width": "^1.5.0",
@@ -14396,6 +14127,7 @@
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
             "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "character-entities-html4": "^2.0.0",
@@ -14432,9 +14164,9 @@
             }
         },
         "node_modules/svgo": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-            "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+            "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14457,11 +14189,41 @@
                 "url": "https://opencollective.com/svgo"
             }
         },
+        "node_modules/svgo/node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/svgo/node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/tailwindcss": {
@@ -14469,8 +14231,7 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
             "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
             "devOptional": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/tapable": {
             "version": "2.3.3",
@@ -14487,9 +14248,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.19",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-            "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+            "version": "7.5.21",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+            "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -14552,9 +14313,9 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.17",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
@@ -14578,23 +14339,23 @@
             }
         },
         "node_modules/tldts": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.6.tgz",
-            "integrity": "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==",
-            "dev": true,
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+            "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "tldts-core": "^7.4.6"
+                "tldts-core": "^7.4.9"
             },
             "bin": {
                 "tldts": "bin/cli.js"
             }
         },
         "node_modules/tldts-core": {
-            "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
-            "integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
-            "dev": true,
+            "version": "7.4.9",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+            "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/to-regex-range": {
@@ -14619,10 +14380,10 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-            "dev": true,
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+            "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+            "devOptional": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tldts": "^7.0.5"
@@ -14635,7 +14396,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
             "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "punycode": "^2.3.1"
@@ -14648,6 +14409,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
             "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -14658,6 +14420,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
             "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -14668,15 +14431,14 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD",
-            "peer": true
+            "license": "0BSD"
         },
         "node_modules/tsx": {
             "version": "4.20.6",
             "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
             "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+            "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "~0.25.0",
                 "get-tsconfig": "^4.7.5"
@@ -15111,6 +14873,7 @@
             "version": "0.25.12",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
             "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -15152,6 +14915,7 @@
             "version": "4.14.0",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
             "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -15211,7 +14975,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -15235,9 +14998,9 @@
             "license": "MIT"
         },
         "node_modules/ultrahtml": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.6.0.tgz",
-            "integrity": "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
+            "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
             "dev": true,
             "license": "MIT"
         },
@@ -15252,22 +15015,24 @@
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
             "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/unified": {
             "version": "11.0.5",
             "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
             "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15299,6 +15064,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
             "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15313,6 +15079,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
             "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
@@ -15326,6 +15093,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
             "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15340,6 +15108,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
             "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
@@ -15353,6 +15122,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
             "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15367,6 +15137,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
             "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
@@ -15380,6 +15151,7 @@
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
             "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15395,6 +15167,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
             "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0"
@@ -15408,6 +15181,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
             "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15525,9 +15299,9 @@
             }
         },
         "node_modules/unstorage/node_modules/lru-cache": {
-            "version": "11.5.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "version": "11.5.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+            "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -15587,6 +15361,7 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
             "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15601,6 +15376,7 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
             "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15615,6 +15391,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
             "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/unist": "^3.0.0",
@@ -15626,16 +15403,15 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-            "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+            "version": "8.1.5",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+            "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
-                "picomatch": "^4.0.4",
-                "postcss": "^8.5.16",
-                "rolldown": "~1.1.3",
+                "picomatch": "^4.0.5",
+                "postcss": "^8.5.17",
+                "rolldown": "~1.1.5",
                 "tinyglobby": "^0.2.17"
             },
             "bin": {
@@ -15703,6 +15479,34 @@
                 }
             }
         },
+        "node_modules/vite/node_modules/picomatch": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/vite/node_modules/tinyglobby": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
         "node_modules/vitefu": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
@@ -15724,19 +15528,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
-            "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+            "version": "4.1.10",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+            "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.1.9",
-                "@vitest/mocker": "4.1.9",
-                "@vitest/pretty-format": "4.1.9",
-                "@vitest/runner": "4.1.9",
-                "@vitest/snapshot": "4.1.9",
-                "@vitest/spy": "4.1.9",
-                "@vitest/utils": "4.1.9",
+                "@vitest/expect": "4.1.10",
+                "@vitest/mocker": "4.1.10",
+                "@vitest/pretty-format": "4.1.10",
+                "@vitest/runner": "4.1.10",
+                "@vitest/snapshot": "4.1.10",
+                "@vitest/spy": "4.1.10",
+                "@vitest/utils": "4.1.10",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -15764,12 +15568,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.9",
-                "@vitest/browser-preview": "4.1.9",
-                "@vitest/browser-webdriverio": "4.1.9",
-                "@vitest/coverage-istanbul": "4.1.9",
-                "@vitest/coverage-v8": "4.1.9",
-                "@vitest/ui": "4.1.9",
+                "@vitest/browser-playwright": "4.1.10",
+                "@vitest/browser-preview": "4.1.10",
+                "@vitest/browser-webdriverio": "4.1.10",
+                "@vitest/coverage-istanbul": "4.1.10",
+                "@vitest/coverage-v8": "4.1.10",
+                "@vitest/ui": "4.1.10",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -15813,11 +15617,18 @@
                 }
             }
         },
+        "node_modules/vitest/node_modules/es-module-lexer": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "devOptional": true,
+            "license": "MIT"
+        },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
             "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "xml-name-validator": "^5.0.0"
@@ -15850,6 +15661,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
             "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",
@@ -15860,7 +15672,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
             "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=20"
@@ -15870,7 +15682,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
             "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -15880,7 +15692,7 @@
             "version": "16.0.1",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
             "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "@exodus/bytes": "^1.11.0",
@@ -15970,7 +15782,7 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
             "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"
@@ -15980,7 +15792,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/xxhash-wasm": {
@@ -16074,11 +15886,10 @@
             }
         },
         "node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
+            "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -16097,6 +15908,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
             "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "github",

--- a/package.json
+++ b/package.json
@@ -19,33 +19,33 @@
         "predev": "npm run prebuild",
         "dev": "astro dev",
         "prebuild": "npm run build:public --workspaces --if-present",
-        "build": "astro build && npm run build:search",
-        "build:search": "npx --yes pagefind@1.5.2 --site dist --exclude-selectors \".sidebar-navigation, .site-search\"",
+        "build": "astro build",
+        "postbuild": "pagefind --site dist --exclude-selectors \".sidebar-navigation, .site-search\"",
         "preview": "astro preview",
+        "debug": "npm run build && astro preview --host 127.0.0.1 --port 4321",
         "astro": "astro",
         "format": "prettier \"!package-lock.json\" . --ignore-path .gitignore --write",
         "format:check": "prettier \"!package-lock.json\" . --ignore-path .gitignore --check"
     },
-    "dependencies": {
-        "@astrojs/markdown-remark": "^7.2.1",
-        "@types/node": "26.1.0",
-        "prettier": "3.8.4",
-        "rehype-raw": "^7.0.0",
-        "tsx": "4.20.6"
-    },
     "devDependencies": {
-        "prettier-plugin-astro": "0.14.1",
+        "@astrojs/markdown-remark": "7.2.1",
         "@astrojs/react": "6.0.1",
         "@tailwindcss/vite": "4.3.2",
+        "@types/node": "26.1.0",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
         "astro": "7.0.6",
         "highlight.js": "11.11.1",
         "markdown-it": "14.2.0",
         "markdown-it-anchor": "9.2.0",
+        "pagefind": "1.5.2",
+        "prettier": "3.8.4",
+        "prettier-plugin-astro": "0.14.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
+        "rehype-raw": "7.0.0",
         "sharp": "0.35.3",
-        "tailwindcss": "4.3.2"
+        "tailwindcss": "4.3.2",
+        "tsx": "4.20.6"
     }
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "angular-ru-interview-questions",
     "version": "1.0.0",
     "private": true,
-    "description": "Вопросы подготовлены непосредственно для того, чтобы определить уровень разработчика, насколько глубоко, поверхностно или сносно он знает Angular. Вопросы для собеседования на знание JavaScript или Web-стека хорошо освещены в других местах, поэтому ниже будет добавлен список ресурсов по этой теме:",
-    "homepage": "https://github.com/Angular-RU/angular-ru-interview-questions#readme",
+    "description": "Справочник с вопросами, ответами и практическими заданиями для подготовки разработчиков к техническим собеседованиям",
+    "homepage": "https://angular-ru.github.io/interview/",
     "bugs": {
         "url": "https://github.com/Angular-RU/angular-ru-interview-questions/issues"
     },
@@ -19,7 +19,8 @@
         "predev": "npm run prebuild",
         "dev": "astro dev",
         "prebuild": "npm run build:public --workspaces --if-present",
-        "build": "astro build",
+        "build": "astro build && npm run build:search",
+        "build:search": "npx --yes pagefind@1.5.2 --site dist --exclude-selectors \".sidebar-navigation, .site-search\"",
         "preview": "astro preview",
         "astro": "astro",
         "format": "prettier \"!package-lock.json\" . --ignore-path .gitignore --write",

--- a/src/components/SiteSearch.astro
+++ b/src/components/SiteSearch.astro
@@ -1,0 +1,30 @@
+---
+interface Props {
+    readonly placeholder?: string;
+    readonly variant?: 'default' | 'hero';
+}
+
+const {placeholder = 'Поиск', variant = 'default'} = Astro.props;
+
+const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
+const pagefindPath = `${basePath}/pagefind`;
+const searchBasePath = `${basePath}/`;
+const searchEnabled = import.meta.env.PROD;
+---
+
+{
+    searchEnabled && (
+        <div
+            class:list={['site-search', variant === 'hero' && 'site-search--hero']}
+            data-pagefind-ignore
+        >
+            <pagefind-config
+                bundle-path={`${pagefindPath}/`}
+                base-url={searchBasePath}
+                lang="ru"
+            />
+            <pagefind-modal-trigger placeholder={placeholder} />
+            <pagefind-modal />
+        </div>
+    )
+}

--- a/src/components/SiteSearch.astro
+++ b/src/components/SiteSearch.astro
@@ -1,10 +1,11 @@
 ---
 interface Props {
+    readonly pagePath?: string;
     readonly placeholder?: string;
     readonly variant?: 'default' | 'hero';
 }
 
-const {placeholder = 'Поиск', variant = 'default'} = Astro.props;
+const {pagePath, placeholder = 'Поиск', variant = 'default'} = Astro.props;
 
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const pagefindPath = `${basePath}/pagefind`;
@@ -16,6 +17,7 @@ const searchEnabled = import.meta.env.PROD;
     searchEnabled && (
         <div
             class:list={['site-search', variant === 'hero' && 'site-search--hero']}
+            data-page-path={pagePath}
             data-pagefind-ignore
         >
             <pagefind-config

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import {ClientRouter} from 'astro:transitions';
 
 import SidebarNavigation from '../components/SidebarNavigation.astro';
+import SiteSearch from '../components/SiteSearch.astro';
 import '../styles/global.css';
 
 interface MarkdownHeading {
@@ -31,11 +32,11 @@ const description =
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPath = Astro.url.pathname.replace(/\/$/, '');
 const homeHref = `${basePath}/`;
-const showHomeLink = currentPath !== basePath;
+const isHomePage = currentPath === basePath;
+const showHomeLink = !isHomePage;
 
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin);
 const pagefindPath = `${basePath}/pagefind`;
-const searchBasePath = `${basePath}/`;
 const searchEnabled = import.meta.env.PROD;
 ---
 
@@ -105,22 +106,7 @@ const searchEnabled = import.meta.env.PROD;
                 class="content"
                 data-pagefind-body
             >
-                {
-                    searchEnabled && (
-                        <div
-                            class="site-search"
-                            data-pagefind-ignore
-                        >
-                            <pagefind-config
-                                bundle-path={`${pagefindPath}/`}
-                                base-url={searchBasePath}
-                                lang="ru"
-                            />
-                            <pagefind-modal-trigger placeholder="Поиск" />
-                            <pagefind-modal />
-                        </div>
-                    )
-                }
+                {!isHomePage && <SiteSearch />}
 
                 <SidebarNavigation
                     headings={headings}
@@ -132,5 +118,21 @@ const searchEnabled = import.meta.env.PROD;
                 <slot />
             </article>
         </main>
+
+        <script>
+            declare global {
+                interface Window {
+                    PagefindComponents?: {
+                        getInstanceManager(): {
+                            removeInstance(name: string): void;
+                        };
+                    };
+                }
+            }
+
+            document.addEventListener('astro:before-swap', () => {
+                window.PagefindComponents?.getInstanceManager().removeInstance('default');
+            });
+        </script>
     </body>
 </html>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,15 +4,39 @@ import {ClientRouter} from 'astro:transitions';
 import SidebarNavigation from '../components/SidebarNavigation.astro';
 import '../styles/global.css';
 
-const {frontmatter} = Astro.props;
+interface MarkdownHeading {
+    readonly depth: number;
+    readonly slug: string;
+    readonly text: string;
+}
 
-const title = frontmatter?.title ?? 'Angular RU Interview Questions';
-const description = frontmatter?.description ?? 'Вопросы и практические задания для подготовки разработчиков';
-const headings = Astro.props.headings ?? [];
+interface Frontmatter {
+    readonly title?: string;
+    readonly description?: string;
+}
+
+interface Props {
+    readonly title?: string;
+    readonly description?: string;
+    readonly frontmatter?: Frontmatter;
+    readonly headings?: readonly MarkdownHeading[];
+}
+
+const {title: titleFromProps, description: descriptionFromProps, frontmatter, headings = []} = Astro.props;
+
+const title = titleFromProps ?? frontmatter?.title ?? 'Angular RU Interview Questions';
+const description =
+    descriptionFromProps ?? frontmatter?.description ?? 'Вопросы и практические задания для подготовки разработчиков';
+
 const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
 const currentPath = Astro.url.pathname.replace(/\/$/, '');
 const homeHref = `${basePath}/`;
 const showHomeLink = currentPath !== basePath;
+
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site ?? Astro.url.origin);
+const pagefindPath = `${basePath}/pagefind`;
+const searchBasePath = `${basePath}/`;
+const searchEnabled = import.meta.env.PROD;
 ---
 
 <!doctype html>
@@ -27,13 +51,77 @@ const showHomeLink = currentPath !== basePath;
             name="viewport"
             content="width=device-width, initial-scale=1.0"
         />
+        <meta
+            name="theme-color"
+            content="#f6f8fb"
+        />
+        <meta
+            property="og:title"
+            content={title}
+        />
+        <meta
+            property="og:description"
+            content={description}
+        />
+        <meta
+            property="og:type"
+            content="website"
+        />
+        <meta
+            property="og:url"
+            content={canonicalUrl}
+        />
+        <meta
+            property="og:locale"
+            content="ru_RU"
+        />
+        <link
+            rel="canonical"
+            href={canonicalUrl}
+        />
+        {
+            searchEnabled && (
+                <link
+                    rel="stylesheet"
+                    href={`${pagefindPath}/pagefind-component-ui.css`}
+                />
+            )
+        }
         <title>{title}</title>
         <ClientRouter />
+        {
+            searchEnabled && (
+                <script
+                    type="module"
+                    src={`${pagefindPath}/pagefind-component-ui.js`}
+                />
+            )
+        }
     </head>
 
     <body>
         <main class="page">
-            <article class="content">
+            <article
+                class="content"
+                data-pagefind-body
+            >
+                {
+                    searchEnabled && (
+                        <div
+                            class="site-search"
+                            data-pagefind-ignore
+                        >
+                            <pagefind-config
+                                bundle-path={`${pagefindPath}/`}
+                                base-url={searchBasePath}
+                                lang="ru"
+                            />
+                            <pagefind-modal-trigger placeholder="Поиск" />
+                            <pagefind-modal />
+                        </div>
+                    )
+                }
+
                 <SidebarNavigation
                     headings={headings}
                     homeHref={homeHref}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -88,6 +88,14 @@ const searchEnabled = import.meta.env.PROD;
                 />
             )
         }
+        {
+            !isHomePage && (
+                <meta
+                    data-pagefind-filter="page[content]"
+                    content={currentPath}
+                />
+            )
+        }
         <title>{title}</title>
         <ClientRouter />
         {
@@ -106,7 +114,7 @@ const searchEnabled = import.meta.env.PROD;
                 class="content"
                 data-pagefind-body
             >
-                {!isHomePage && <SiteSearch />}
+                {!isHomePage && <SiteSearch pagePath={currentPath} />}
 
                 <SidebarNavigation
                     headings={headings}
@@ -120,10 +128,17 @@ const searchEnabled = import.meta.env.PROD;
         </main>
 
         <script>
+            interface PagefindModalElement extends HTMLElement {
+                close(): void;
+            }
+
             declare global {
                 interface Window {
                     PagefindComponents?: {
                         getInstanceManager(): {
+                            getInstance(name: string): {
+                                triggerFilter(name: string, values: ReadonlyArray<string>): void;
+                            };
                             removeInstance(name: string): void;
                         };
                     };
@@ -132,6 +147,54 @@ const searchEnabled = import.meta.env.PROD;
 
             document.addEventListener('astro:before-swap', () => {
                 window.PagefindComponents?.getInstanceManager().removeInstance('default');
+            });
+
+            document.addEventListener('astro:page-load', () => {
+                const pagePath = document.querySelector<HTMLElement>('.site-search')?.dataset.pagePath;
+                const searchModal = document.querySelector<PagefindModalElement>('.site-search pagefind-modal');
+
+                if (pagePath) {
+                    window.PagefindComponents?.getInstanceManager()
+                        .getInstance('default')
+                        .triggerFilter('page', [pagePath]);
+                }
+
+                searchModal?.addEventListener('click', (event) => {
+                    const resultLink =
+                        event.target instanceof Element ? event.target.closest<HTMLAnchorElement>('a[href]') : null;
+
+                    if (!resultLink) {
+                        return;
+                    }
+
+                    const resultUrl = new URL(resultLink.href);
+                    const isCurrentPageResult =
+                        resultUrl.origin === window.location.origin &&
+                        resultUrl.pathname === window.location.pathname &&
+                        resultUrl.search === window.location.search &&
+                        Boolean(resultUrl.hash);
+
+                    if (!isCurrentPageResult) {
+                        return;
+                    }
+
+                    const dialog = searchModal.querySelector('dialog');
+
+                    if (!dialog) {
+                        return;
+                    }
+
+                    event.preventDefault();
+                    dialog.addEventListener(
+                        'close',
+                        () => {
+                            window.location.hash = resultUrl.hash;
+                            document.getElementById(decodeURIComponent(resultUrl.hash.slice(1)))?.scrollIntoView();
+                        },
+                        {once: true},
+                    );
+                    searchModal.close();
+                });
             });
         </script>
     </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,6 +4,7 @@ import '../styles/home.css';
 import Layout from '../layouts/Layout.astro';
 import HeroSpaceIllustration from '../components/HeroSpaceIllustration.astro';
 import HomeSection from '../components/HomeSection.astro';
+import SiteSearch from '../components/SiteSearch.astro';
 import {examples} from '../data/examples';
 
 type MarkdownModule = {
@@ -166,6 +167,11 @@ const exampleCards = examples.slice().sort((a, b) => a.order - b.order);
                     Вопросы, ответы и практические демо для подготовки разработчиков: инженерные основы, Frontend,
                     Backend, архитектура, инфраструктура и soft skills.
                 </p>
+
+                <SiteSearch
+                    placeholder="Найти вопрос, тему или технологию..."
+                    variant="hero"
+                />
 
                 <div
                     class="hero-navigation"

--- a/src/plugins/rehype-unwrap-details-table.ts
+++ b/src/plugins/rehype-unwrap-details-table.ts
@@ -33,6 +33,83 @@ const getSingleCellChildren = (table: Element): ElementContent[] | null => {
     return cells[0].children;
 };
 
+const getTextContent = (node: Node): string => {
+    if (node.type === 'text') {
+        return node.value;
+    }
+
+    if (!('children' in node)) {
+        return '';
+    }
+
+    return node.children.map((child) => getTextContent(child)).join('');
+};
+
+const createSlug = (value: string): string =>
+    value
+        .toLocaleLowerCase('ru')
+        .trim()
+        .replace(/[^\p{Letter}\p{Number}\s-]/gu, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '');
+
+const createUniqueId = (baseId: string, usedIds: Set<string>): string => {
+    let id = baseId;
+    let suffix = 2;
+
+    while (usedIds.has(id)) {
+        id = `${baseId}-${suffix}`;
+        suffix += 1;
+    }
+
+    usedIds.add(id);
+
+    return id;
+};
+
+const indexSummary = (details: Element, usedIds: Set<string>): void => {
+    if (details.tagName !== 'details') {
+        return;
+    }
+
+    const summary = getElementChildren(details, 'summary')[0];
+
+    if (
+        !summary ||
+        getElementChildren(summary).some((child) => /^h[1-6]$/.test(child.tagName))
+    ) {
+        return;
+    }
+
+    const question = getTextContent(summary).trim();
+
+    if (!question) {
+        return;
+    }
+
+    const explicitId =
+        typeof summary.properties.id === 'string' ? summary.properties.id : '';
+    const generatedId = `question-${createSlug(question) || 'untitled'}`;
+    const id = explicitId || createUniqueId(generatedId, usedIds);
+
+    if (explicitId) {
+        delete summary.properties.id;
+    }
+
+    summary.children = [
+        {
+            type: 'element',
+            tagName: 'h4',
+            properties: {
+                className: ['question-search-heading'],
+                id,
+            },
+            children: summary.children,
+        },
+    ];
+};
+
 const unwrapDetailsTable = (details: Element): void => {
     if (details.tagName !== 'details') {
         return;
@@ -72,18 +149,32 @@ const unwrapDetailsTable = (details: Element): void => {
     details.children = nextChildren;
 };
 
-const walk = (node: Node): void => {
-    if (isElement(node)) {
-        unwrapDetailsTable(node);
+const collectIds = (node: Node, usedIds: Set<string>): void => {
+    if (isElement(node) && typeof node.properties.id === 'string') {
+        usedIds.add(node.properties.id);
     }
 
     if ('children' in node) {
-        node.children.forEach((child) => walk(child));
+        node.children.forEach((child) => collectIds(child, usedIds));
+    }
+};
+
+const walk = (node: Node, usedIds: Set<string>): void => {
+    if (isElement(node)) {
+        unwrapDetailsTable(node);
+        indexSummary(node, usedIds);
+    }
+
+    if ('children' in node) {
+        node.children.forEach((child) => walk(child, usedIds));
     }
 };
 
 export const rehypeUnwrapDetailsTable = () => {
     return (tree: Root): void => {
-        walk(tree);
+        const usedIds = new Set<string>();
+
+        collectIds(tree, usedIds);
+        walk(tree, usedIds);
     };
 };

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -81,7 +81,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
-    margin-top: 34px;
+    margin-top: 22px;
 }
 
 .home .navigation-chip {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -13,6 +13,27 @@
     box-shadow: var(--shadow-page);
 }
 
+.site-search {
+    --pf-text: var(--text);
+    --pf-text-secondary: var(--body);
+    --pf-text-muted: var(--muted);
+    --pf-background: var(--surface);
+    --pf-border: var(--border);
+    --pf-border-focus: var(--accent);
+    --pf-hover: var(--accent-soft);
+    --pf-mark: var(--accent-strong);
+    --pf-outline-focus: var(--accent);
+    --pf-font: inherit;
+
+    display: flex;
+    justify-content: flex-end;
+    margin-block-end: 24px;
+}
+
+.site-search pagefind-modal-trigger {
+    display: block;
+}
+
 @media (max-width: 700px) {
     .page {
         width: min(100% - 24px, 1120px);

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -34,6 +34,10 @@
     display: block;
 }
 
+.site-search .pf-input {
+    padding-inline-end: 7rem !important;
+}
+
 .site-search--hero {
     --pf-input-height: 54px;
     --pf-border-radius: 14px;

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -34,6 +34,20 @@
     display: block;
 }
 
+.site-search--hero {
+    --pf-input-height: 54px;
+    --pf-border-radius: 14px;
+
+    width: 100%;
+    max-width: 660px;
+    justify-content: stretch;
+    margin: 28px 0 0;
+}
+
+.site-search--hero pagefind-modal-trigger {
+    width: 100%;
+}
+
 @media (max-width: 700px) {
     .page {
         width: min(100% - 24px, 1120px);

--- a/src/styles/markdown-details.css
+++ b/src/styles/markdown-details.css
@@ -16,6 +16,17 @@
     list-style-position: outside;
 }
 
+.content summary .question-search-heading {
+    display: block;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    color: inherit;
+    background: transparent;
+    font: inherit;
+}
+
 .content details[open] summary {
     border-bottom: 1px solid var(--border);
     background: #f8fafc;


### PR DESCRIPTION
## Что изменено

- добавлен глобальный поиск по вопросам и ответам через Pagefind;
- добавлена модальная поисковая форма с горячей клавишей `Cmd/Ctrl + K`;
- учтен базовый путь публикации `/interview/` для ресурсов и ссылок результатов;
- навигация и сам поисковый интерфейс исключены из индекса;
- `Layout` теперь принимает `title` и `description` как прямые props, поэтому metadata главной страницы больше не теряется;
- добавлены canonical URL, Open Graph metadata и `theme-color`;
- обновлены `description` и `homepage` пакета;
- Pagefind запускается после сборки Astro с зафиксированной версией `1.5.2`.

## Зачем

Репозиторий вырос в большую базу вопросов по нескольким направлениям. Навигации по карточкам и оглавлению уже недостаточно для быстрого поиска конкретной темы. Одновременно главная страница передавала metadata в `Layout`, но layout читал только `frontmatter`, поэтому эти значения игнорировались.

## Пользовательский эффект

Пользователь может открыть поиск с любой страницы, найти вопрос по формулировке или содержимому ответа и перейти к соответствующему разделу. Ссылки результатов корректно работают при публикации сайта в подпути GitHub Pages.

## Проверка

- [x] `npm run format:check`
- [x] `npm run build` — Astro build и генерация индекса Pagefind
- [x] итоговый diff содержит только `package.json`, `src/layouts/Layout.astro` и `src/styles/layout.css`