### PR TITLE
fix: simplify mobile content layout

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -54,12 +54,14 @@
 
 @media (max-width: 700px) {
     .page {
-        width: min(100% - 24px, 1120px);
-        padding: 24px 0 48px;
+        width: 100%;
+        padding: 0 0 48px;
     }
 
     .content {
-        padding: 24px 18px;
-        border-radius: 16px;
+        padding: 24px 16px;
+        border: 0;
+        border-radius: 0;
+        box-shadow: none;
     }
 }

--- a/src/styles/markdown-details.css
+++ b/src/styles/markdown-details.css
@@ -152,3 +152,14 @@
     padding: 20px 24px;
     border: 0;
 }
+
+@media (max-width: 700px) {
+    .content details .answer,
+    .content details > table td {
+        padding: 16px;
+    }
+
+    .content details .answer-short {
+        padding: 14px 16px;
+    }
+}


### PR DESCRIPTION
## Что изменено

- убран внешний отступ страницы на мобильных экранах;
- основной контент растянут на всю ширину viewport;
- убраны border, border-radius и shadow у внешнего content-блока на mobile;
- сохранен белый фон основного контента, чтобы не показывать серый фон body по краям;
- уменьшены горизонтальные отступы внутри раскрытого ответа и блока короткого ответа.

## Зачем

На узких экранах несколько вложенных padding заметно сокращали полезную ширину текста. После изменений карточки вопросов остаются визуально отделенными, но основной контейнер больше не выглядит как вложенная desktop-карточка.