### PR TITLE
style: soften inline code in short answers

### DIFF
--- a/src/styles/markdown-details.css
+++ b/src/styles/markdown-details.css
@@ -68,6 +68,10 @@
     background: var(--accent-soft);
 }
 
+.content details .answer-short code {
+    background: color-mix(in srgb, var(--code-bg) 40%, var(--accent-soft));
+}
+
 .content details .answer-short > :last-child,
 .content details .answer-full > :last-child {
     margin-bottom: 0;


### PR DESCRIPTION
Снижает визуальный контраст inline `code` внутри блока «Короткий ответ».

Изменение локальное: обычные code-теги в полном ответе и остальных Markdown-блоках не затрагиваются.