### PR TITLE
docs(js): add Promise.any AggregateError question

### DIFF
--- a/src/pages/javascript/index.md
+++ b/src/pages/javascript/index.md
@@ -1214,6 +1214,32 @@ promises, он завершается `AggregateError`.
 </details>
 
 <details>
+<summary>С какой ошибкой завершится <code>Promise.any()</code>, если все promises будут отклонены?</summary><br>
+<table><tr><td>
+
+**Короткий ответ**
+
+`AggregateError`.
+
+**Полный ответ**
+
+Если все переданные promises завершатся с rejection, `Promise.any()` отклонит итоговый promise с `AggregateError`. В
+свойстве `errors` находятся причины всех отклонений в порядке переданных promises.
+
+```js
+try {
+  await Promise.any([Promise.reject('A'), Promise.reject('B')]);
+} catch (error) {
+  console.log(error instanceof AggregateError); // true
+  console.log(error.errors); // ['A', 'B']
+}
+```
+
+</td></tr></table>
+
+</details>
+
+<details>
 <summary>Что такое Promise.withResolvers?</summary><br>
 <table><tr><td>
 


### PR DESCRIPTION
Добавляет отдельный JavaScript-вопрос про ошибку, с которой завершается `Promise.any()`, если все переданные promises отклонены.

Короткий ответ: `AggregateError`.

Также добавлен пример с `AggregateError.errors`.