### PR TITLE
chore: use shared Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-    "extends": ["config:best-practices"]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["github>taiga-family/renovate-config"]
 }


### PR DESCRIPTION
Use the shared Renovate preset from `taiga-family/renovate-config` instead of the local `config:best-practices` preset.

```json
"extends": ["github>taiga-family/renovate-config"]
```