### PR TITLE
fix: override unsupported Renovate env

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "env": {},
     "extends": ["github>taiga-family/renovate-config"]
 }


### PR DESCRIPTION
## What changed

Override inherited Renovate `env` with an empty object.

The shared `github>taiga-family/renovate-config` preset defines several `NPM_CONFIG_*` environment variables, but Mend-hosted Renovate does not allow those variable names. Since `env` is non-mergeable, the repository-level empty object replaces the inherited values while keeping the rest of the shared preset intact.

Closes #106.