### PR TITLE
fix: group Angular minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "env": {},
-    "extends": ["github>taiga-family/renovate-config"]
+    "extends": ["github>taiga-family/renovate-config"],
+    "packageRules": [
+        {
+            "matchPackageNames": [
+                "/^@angular\\//",
+                "/^@angular-devkit\\//",
+                "/^@schematics\\//",
+                "ng-packagr"
+            ],
+            "separateMinorPatch": false
+        }
+    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,7 @@
     "extends": ["github>taiga-family/renovate-config"],
     "packageRules": [
         {
-            "matchPackageNames": [
-                "/^@angular\\//",
-                "/^@angular-devkit\\//",
-                "/^@schematics\\//",
-                "ng-packagr"
-            ],
+            "matchPackageNames": ["/^@angular\\//", "/^@angular-devkit\\//", "/^@schematics\\//", "ng-packagr"],
             "separateMinorPatch": false
         }
     ]


### PR DESCRIPTION
## What changed

Override the inherited Angular Renovate rule with `separateMinorPatch: false`.

This keeps `@angular/*`, `@angular-devkit/*`, `@schematics/*`, and `ng-packagr` updates in the same Renovate group even when some packages have patch updates and others have minor updates.

The shared `taiga-family/renovate-config` preset will be updated separately as well, so this repository-level override can be removed after the shared preset change is merged.